### PR TITLE
Add type of the object to the index file of che-plugin-registry

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -7,12 +7,20 @@ echo "["
 ## now loop through meta files
 for i in "${arr[@]}"
 do
-    IFS='/' segments=($i)
     if [ "$FIRST_LINE" = true ] ; then
-        echo \{\"name\":\"${segments[2]}\",\"version\":\"${segments[3]}\"\}
+        echo "{"
         FIRST_LINE=false
     else
-        echo \,\{\"name\":\"${segments[2]}\",\"version\":\"${segments[3]}\"\}
+        echo ",{"
     fi
+    # 1. read meta.yaml to stio
+    # 2. filter lines with name,version,type
+    # 3. Replace ` :` with `":"`
+    # 4. Append `",` to the end of each line
+    # 5. Append `"` at the begining of each line
+    # 6. Remove all new lines
+    # 7. Remove last ','
+    cat $i|grep -e name -e version -e type |   sed 's/: /\":"/g'  | sed 's/$/\",/g' | sed 's/^/\"/g'  | tr -d '\n' |  sed 's/,$//g'
+    echo "}"
 done
 echo "]"

--- a/index.sh
+++ b/index.sh
@@ -13,14 +13,21 @@ do
     else
         echo ",{"
     fi
+
     # 1. read meta.yaml to stio
-    # 2. filter lines with name,version,type
-    # 3. Replace ` :` with `":"`
-    # 4. Append `",` to the end of each line
-    # 5. Append `"` at the begining of each line
-    # 6. Remove all new lines
-    # 7. Remove last ','
-    cat $i|grep -e name -e version -e type |   sed 's/: /\":"/g'  | sed 's/$/\",/g' | sed 's/^/\"/g'  | tr -d '\n' |  sed 's/,$//g'
+    cat $i| \
+        # 2. filter lines with name,version,type
+        grep -e name -e version -e type |\
+        # 3. Replace ` :` with `":"`
+        sed 's/: /\":"/g'  |\
+        # 4. Append `",` to the end of each line
+        sed 's/$/\",/g' |\
+        # 5. Append `"` at the beginning of each line
+        sed 's/^/\"/g'  |\
+        # 6. Remove all new lines
+        tr -d '\n' |\
+        # 7. Remove last ','
+        sed 's/,$//g'
     echo "}"
 done
 echo "]"


### PR DESCRIPTION
### What does this PR do?

Add type of the object to the index file of che-plugin-registry


![2018-08-15 12 50 41](https://user-images.githubusercontent.com/1614429/44142751-dbf25306-a089-11e8-99a9-f34c6f9d4f78.png)


### Reference to
https://github.com/eclipse/che/issues/10781

