### PR TITLE
Fix location of meta file of Theia editor

### DIFF
--- a/plugins/org.eclipse.che.editor.theia/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.theia/1.0.0/meta.yaml
@@ -1,7 +1,7 @@
-id: theia-ide
+id: org.eclipse.che.editor.theia
 version: 1.0.0
 type: Che Editor
-name: org.eclipse.che.editor.theia
+name: theia-ide
 title: Eclipse Theia for Eclipse Che
 description: Eclipse Theia
 icon: https://pbs.twimg.com/profile_images/929088242456190976/xjkS2L-0_400x400.jpg


### PR DESCRIPTION
### What does this PR do?
Rename the folder with Theia meta.yaml to its ID since Che master
build download path by ID/version and current location is
incorrect.
Also fixes mixed ID/Name fields content.