### PR TITLE
Add field 'id' to index

### DIFF
--- a/index.sh
+++ b/index.sh
@@ -17,7 +17,7 @@ do
     # 1. read meta.yaml to stio
     cat $i| \
         # 2. filter lines with name,version,type
-        grep -e name -e version -e type -e 'id:' |\
+        grep -e 'name:' -e 'version:' -e 'type:' -e 'id:' |\
         # 3. Replace ` :` with `":"`
         sed 's/: /\":"/g'  |\
         # 4. Append `",` to the end of each line

--- a/index.sh
+++ b/index.sh
@@ -17,7 +17,7 @@ do
     # 1. read meta.yaml to stio
     cat $i| \
         # 2. filter lines with name,version,type
-        grep -e name -e version -e type |\
+        grep -e name -e version -e type -e 'id:' |\
         # 3. Replace ` :` with `":"`
         sed 's/: /\":"/g'  |\
         # 4. Append `",` to the end of each line


### PR DESCRIPTION
### What does this PR do?
Field 'id' is needed because a client should add it along with
the version to Che workspace attributes.