### PR TITLE
Added Apache index files configuration

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,2 @@
 Header set Access-Control-Allow-Origin "*"
+DirectoryIndex index.json

--- a/.htaccess
+++ b/.htaccess
@@ -1,2 +1,2 @@
 Header set Access-Control-Allow-Origin "*"
-DirectoryIndex index.json
+DirectoryIndex README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY check_plugins_location.sh /test/check_plugins_location.sh
 RUN cd /test/ && ./check_plugins_location.sh
 
 FROM registry.centos.org/centos/httpd-24-centos7
+RUN mkdir /var/www/html/plugins
 COPY /plugins /var/www/html/plugins
-COPY index.sh /var/www/html/
-COPY .htaccess /var/www/html/
-RUN cd /var/www/html/ && ./index.sh > index.json && rm index.sh
+COPY index.sh .htaccess  README.md /var/www/html/
+RUN cd /var/www/html/ && ./index.sh > plugins/index.json && rm index.sh

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -10,11 +10,10 @@ EXPOSE 80
 RUN chmod a+rwX            /etc/httpd/conf
 RUN chmod a+rwX            /run/httpd
 
+RUN mkdir /var/www/html/plugins
 COPY /plugins /var/www/html/plugins
-COPY index.sh /var/www/html/
-COPY .htaccess /var/www/html/
-RUN cd /var/www/html/ && ./index.sh > index.json && rm index.sh
-
+COPY index.sh .htaccess  README.md /var/www/html/
+RUN cd /var/www/html/ && ./index.sh > plugins/index.json && rm index.sh
 
 STOPSIGNAL SIGWINCH
 

--- a/plugins/.htaccess
+++ b/plugins/.htaccess
@@ -1,0 +1,1 @@
+DirectoryIndex meta.yaml

--- a/plugins/.htaccess
+++ b/plugins/.htaccess
@@ -1,1 +1,1 @@
-DirectoryIndex meta.yaml
+DirectoryIndex meta.yaml index.json


### PR DESCRIPTION
### What does this PR do?
Reference issue https://github.com/eclipse/che-plugin-registry/issues/26

1. Return readme on http://localhost:8080/ 
![2018-09-12 14 27 02](https://user-images.githubusercontent.com/1614429/45422236-48f37880-b698-11e8-8eee-5e1454ac982a.png)

I didn't want to maintain two readme for now and it's quite hard to add md->html convertor for this image ```FROM quay.io/openshiftio/rhel-base-httpd:latest``` that is why it shows raw md.

2. Return index.json on  http://localhost:8080/plugins
![2018-09-12 14 27 11](https://user-images.githubusercontent.com/1614429/45422251-5872c180-b698-11e8-9917-73386bf6b355.png)
3. Return meta.yaml for plugins requests 
![2018-09-12 14 27 21](https://user-images.githubusercontent.com/1614429/45423809-1304c300-b69d-11e8-8956-c5705d3104aa.png)


