### PR TITLE
Prevent caching of index file by browser

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,2 +1,17 @@
 Header set Access-Control-Allow-Origin "*"
 DirectoryIndex README.md
+<FilesMatch "\.(json|yaml)$">
+    <IfModule mod_expires.c>
+	ExpiresActive Off
+    </IfModule>
+    <IfModule mod_headers.c>
+	FileETag None
+	Header unset ETag
+	Header unset Pragma
+	Header unset Cache-Control
+	Header unset Last-Modified
+	Header set Pragma "no-cache"
+	Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+	Header set Expires "Mon, 10 Apr 1972 00:00:00 GMT"
+    </IfModule>
+</FilesMatch>


### PR DESCRIPTION
### What does this PR do?
Configure apache to disable caching.
Fixes https://github.com/eclipse/che-plugin-registry/issues/30
Before 
```
[ 9:51:32]sj:~#: curl -v  "http://localhost:8080/plugins/"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /plugins/ HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Mon, 24 Sep 2018 06:51:40 GMT
< Server: Apache/2.4.27 (Red Hat) OpenSSL/1.0.2k-fips
< Last-Modified: Mon, 24 Sep 2018 06:50:35 GMT
< ETag: "3e2-5769867f884c0"
< Accept-Ranges: bytes
< Content-Length: 994
< Access-Control-Allow-Origin: *
< Content-Type: application/json
```
after
```
[ 9:52:08]sj:~#: curl -v  "http://localhost:8080/plugins/"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /plugins/ HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Mon, 24 Sep 2018 06:54:44 GMT
< Server: Apache/2.4.27 (Red Hat) OpenSSL/1.0.2k-fips
< Accept-Ranges: bytes
< Content-Length: 994
< Access-Control-Allow-Origin: *
< Pragma: no-cache
< Cache-Control: max-age=0, no-cache, no-store, must-revalidate
< Expires: Mon, 10 Apr 1972 00:00:00 GMT
< Content-Type: application/json
<
```



before
```

 9:51:37]sj:~#: curl -v  "http://localhost:8080/plugins/che-machine-exec-plugin/0.0.1/meta.yaml"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /plugins/che-machine-exec-plugin/0.0.1/meta.yaml HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Mon, 24 Sep 2018 06:52:10 GMT
< Server: Apache/2.4.27 (Red Hat) OpenSSL/1.0.2k-fips
< Last-Modified: Mon, 24 Sep 2018 06:48:51 GMT
< ETag: "1a6-5769861c59ac0"
< Accept-Ranges: bytes
< Content-Length: 422
< Access-Control-Allow-Origin: *
<
```
after
```
 9:54:42]sj:~#: curl -v  "http://localhost:8080/plugins/che-machine-exec-plugin/0.0.1/meta.yaml"
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /plugins/che-machine-exec-plugin/0.0.1/meta.yaml HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Mon, 24 Sep 2018 06:55:07 GMT
< Server: Apache/2.4.27 (Red Hat) OpenSSL/1.0.2k-fips
< Accept-Ranges: bytes
< Content-Length: 422
< Access-Control-Allow-Origin: *
< Pragma: no-cache
< Cache-Control: max-age=0, no-cache, no-store, must-revalidate
< Expires: Mon, 10 Apr 1972 00:00:00 GMT
<
```
