### PR TITLE
Do not use word 'IDE' for Jupyter Notebook description

### DIFF
--- a/plugins/org.eclipse.che.editor.jupyter/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.jupyter/1.0.0/meta.yaml
@@ -1,8 +1,8 @@
 id: org.eclipse.che.editor.jupyter
 version: 1.0.0
 type: Che Editor
-name: jupyter-ide
-title: Project Jupyter for Eclipse Che
-description: Project Jupyter
+name: jupyter-notebook
+title: Jupyter Notebook as Editor for Eclipse Che
+description: Jupyter Notebook as Editor for Eclipse Che
 icon: https://jupyter.org/assets/main-logo.svg
-url: https://github.com/ws-skeleton/che-editor-jupyter/releases/download/untagged-07684402a512ed39ad8c/che-editor-plugin.tar.gz
+url: https://github.com/ws-skeleton/che-editor-jupyter/releases/download/untagged-cc4e4c9a7741551b6776/che-editor-plugin.tar.gz


### PR DESCRIPTION
### What does this PR do?
Jupyter is not really IDE, so this PR removes usage of word ide in editor description

### Related PR
It is related to https://github.com/ws-skeleton/che-editor-jupyter/pull/1