### PR TITLE
Added an Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can deploy Che plugin registry on Openshift with command.
 
 ## Kubernetes
 
-You can deploy Che plugin registry on Kubernetes using [helm](https://docs.helm.sh/).
+You can deploy Che plugin registry on Kubernetes using [helm](https://docs.helm.sh/). For example if you want to deploy it in the namespace `kube-che` and you are using `minikube` you can use the following command.
 
 ```bash
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ You can deploy Che plugin registry on Openshift with command.
              -p IMAGE_TAG="latest" \
              -p PULL_POLICY="IfNotPresent"
 ```
+
+## Kubernetes
+
+You can deploy Che plugin registry on Kubernetes using [helm](https://docs.helm.sh/).
+
+```bash
+
+NAMESPACE="kube-che"
+DOMAIN="$(minikube ip).nip.io"
+helm upgrade --install che-plugin-registry \
+    --debug \
+    --namespace ${NAMESPACE} \
+    --set global.ingressDomain=${DOMAIN} \
+    ./kubernetes/che-plugin-registry/
+
+```
+
+You can use the following command to uninstall it.
+
+```bash
+
+helm delete --purge che-plugin-registry
+
+```
+
 ## Docker
 ```
 docker run -it  --rm  -p 8080:8080 eclipse/che-plugin-registry

--- a/kubernetes/che-plugin-registry/Chart.yaml
+++ b/kubernetes/che-plugin-registry/Chart.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2012-2017 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: "v1"
+name: "che-plugin-registry-service"
+version: "0.0.1"
+home: "https://github.com/eclipse/che-plugin-registry/"

--- a/kubernetes/che-plugin-registry/Chart.yaml
+++ b/kubernetes/che-plugin-registry/Chart.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2017 Red Hat, Inc.
+# Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/kubernetes/che-plugin-registry/README.md
+++ b/kubernetes/che-plugin-registry/README.md
@@ -1,0 +1,3 @@
+# Che Plugin Registry Helm Chart
+
+This Helm Chart install [Che](https://github.com/eclipse/che) Plugin Registry. More information about Che Plugin Registry can be found [here](https://github.com/eclipse/che-plugin-registry).

--- a/kubernetes/che-plugin-registry/templates/deployment.yaml
+++ b/kubernetes/che-plugin-registry/templates/deployment.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/kubernetes/che-plugin-registry/templates/deployment.yaml
+++ b/kubernetes/che-plugin-registry/templates/deployment.yaml
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: che-plugin-registry
+  name: che-plugin-registry
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: che-plugin-registry
+  strategy:
+    type: RollingUpdate
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+  template:
+    metadata:
+      labels:
+        app: che-plugin-registry
+    spec:
+      containers:
+      - image: {{ .Values.chePluginRegistryImage }}
+        imagePullPolicy: {{ .Values.chePluginRegistryImagePullPolicy }}
+        name: che-plugin-registry
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /plugins/
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /plugins/
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.chePluginRegistryMemoryLimit }}
+          requests:
+            memory: 256Mi

--- a/kubernetes/che-plugin-registry/templates/ingress.yaml
+++ b/kubernetes/che-plugin-registry/templates/ingress.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2012-2017 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: che-plugin-registry
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - host: {{ printf "che-plugin-registry-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: che-plugin-registry
+          servicePort: 8080

--- a/kubernetes/che-plugin-registry/templates/ingress.yaml
+++ b/kubernetes/che-plugin-registry/templates/ingress.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2017 Red Hat, Inc.
+# Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/kubernetes/che-plugin-registry/templates/service.yaml
+++ b/kubernetes/che-plugin-registry/templates/service.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2017 Red Hat, Inc.
+# Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/kubernetes/che-plugin-registry/templates/service.yaml
+++ b/kubernetes/che-plugin-registry/templates/service.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2012-2017 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: che-plugin-registry
+  name: che-plugin-registry
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  selector:
+    app: che-plugin-registry

--- a/kubernetes/che-plugin-registry/values.yaml
+++ b/kubernetes/che-plugin-registry/values.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2012-2017 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+chePluginRegistryImage: eclipse/che-plugin-registry
+chePluginRegistryImagePullPolicy: Always
+chePluginRegistryMemoryLimit: 256Mi
+
+global:
+  ingressDomain: 192.168.99.100.nip.io

--- a/kubernetes/che-plugin-registry/values.yaml
+++ b/kubernetes/che-plugin-registry/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2017 Red Hat, Inc.
+# Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/openshift/che-plugin-registry.yml
+++ b/openshift/che-plugin-registry.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
### What does this PR do?

Currently the README.md had only instructions to deploy the registry on Docker and OpenShift. This PR adds an Helm Chart and the instructions to use it to deploy the registry on Kubernetes.
