### PR TITLE
Introduce Che/Theia dev plug-in

### DIFF
--- a/plugins/org.eclipse.che.theia.dev/0.0.1/meta.yaml
+++ b/plugins/org.eclipse.che.theia.dev/0.0.1/meta.yaml
@@ -1,0 +1,8 @@
+id: org.eclipse.che.theia.dev
+version: 0.0.1
+type: Che Plugin
+name: Che Theia Dev Plugin
+title: Che Theia Dev Plugin
+description: Che Theia Dev Plugin
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+url: https://github.com/che-incubator/che-theia-dev-plugin/releases/download/0.0.1/che-theia-dev-plugin.tar.gz


### PR DESCRIPTION
### What does this PR do?

This plug-in brings the theia development container used to build che/theia with required tools

So, create Che7 stack, pickup this plug-in and then a theia-dev container is brought 
this one: https://github.com/eclipse/che/tree/master/dockerfiles/theia-dev

It allows to work with the custom Che/Theia

Change-Id: I165d8934d82da045f2ababfc62275408d831bd50
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
