### PR TITLE
Update url of che-editor-gwt-ide

### DIFF
--- a/plugins/org.eclipse.che.editor.gwt/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.gwt/1.0.0/meta.yaml
@@ -5,4 +5,4 @@ name: gwt-ide
 title: Eclipse GWT IDE for Eclipse Che
 description: Eclipse GWT IDE
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-url: https://github.com/skabashnyuk/che-editor-gwt-ide/releases/download/untagged-c615b3964b2022b5896f/che-editor-plugin.tar.gz
+url: https://github.com/eclipse/che-editor-gwt-ide/releases/download/che-editor-gwt-ide-2018-12-18_1600-56/che-editor-plugin.tar.gz

--- a/plugins/org.eclipse.che.editor.gwt/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.gwt/1.0.0/meta.yaml
@@ -5,4 +5,4 @@ name: gwt-ide
 title: Eclipse GWT IDE for Eclipse Che
 description: Eclipse GWT IDE
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-url: https://github.com/eclipse/che-editor-gwt-ide/releases/download/che-editor-gwt-ide-2018-12-18_1600-56/che-editor-plugin.tar.gz
+url: https://github.com/eclipse/che-editor-gwt-ide/releases/download/che-editor-gwt-ide-2018-12-18_2212-00/che-editor-plugin.tar.gz


### PR DESCRIPTION
### What does this PR do?
Update url of che-editor-gwt-ide. Now it points to https://github.com/eclipse/che-editor-gwt-ide repository releases

## Related 
related to https://github.com/eclipse/che/issues/12172 
