### PR TITLE
Add & validate more fields for plugin viewer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
-FROM mikefarah/yq
+#
+# Copyright (c) 2012-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+FROM mikefarah/yq as builder
 RUN apk add --no-cache bash
-COPY /plugins /test/plugins
-COPY check_plugins_location.sh /test/check_plugins_location.sh
-COPY check_plugins_images.sh /test/check_plugins_images.sh
-RUN cd /test/ && ./check_plugins_location.sh && ./check_plugins_images.sh
+COPY .htaccess README.md /build/
+COPY /plugins /build/plugins
+COPY check_plugins_location.sh check_plugins_images.sh check_plugins_viewer_mandatory_fields.sh index.sh set_plugin_dates.sh /build/
+RUN cd /build/ && ./check_plugins_location.sh && ./check_plugins_images.sh && ./set_plugin_dates.sh ./check_plugins_viewer_mandatory_fields.sh && ./index.sh > /build/plugins/index.json
+COPY .htaccess README.md /build/
 
 FROM registry.centos.org/centos/httpd-24-centos7
 RUN mkdir /var/www/html/plugins
-COPY /plugins /var/www/html/plugins
-COPY index.sh .htaccess  README.md /var/www/html/
-RUN cd /var/www/html/ && ./index.sh > plugins/index.json && rm index.sh
+COPY --from=builder /build/ /var/www/html/
 USER 0
 RUN chmod -R g+rwX /var/www/html/plugins

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2012-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+FROM mikefarah/yq as builder
+RUN apk add --no-cache bash
+COPY .htaccess README.md /build/
+COPY /plugins /build/plugins
+COPY check_plugins_location.sh check_plugins_images.sh check_plugins_viewer_mandatory_fields.sh index.sh set_plugin_dates.sh /build/
+RUN cd /build/ && ./check_plugins_location.sh && ./check_plugins_images.sh && ./set_plugin_dates.sh ./check_plugins_viewer_mandatory_fields.sh && ./index.sh > /build/plugins/index.json
+COPY .htaccess README.md /build/
+
 FROM quay.io/openshiftio/rhel-base-httpd:latest
 
 RUN sed -i -e "s,Listen 80,Listen 8080," /etc/httpd/conf/httpd.conf
@@ -12,9 +28,7 @@ RUN chmod a+rwX            /etc/httpd/conf
 RUN chmod a+rwX            /run/httpd
 
 RUN mkdir /var/www/html/plugins
-COPY /plugins /var/www/html/plugins
-COPY index.sh .htaccess  README.md /var/www/html/
-RUN cd /var/www/html/ && ./index.sh > plugins/index.json && rm index.sh
+COPY --from=builder /build/ /var/www/html/
 
 STOPSIGNAL SIGWINCH
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Useful when you change plugin metadata files and rebuild the image.
 
 ## https://hub.docker.com/
 
+Note that the Dockerfiles feature multi-stage build, so it requires Docker of version 17.05 and higher.  
+Though you may also just provide the image to the older versions of Docker (ex. on Minishift) by having it build on newer version, and pushing and pulling it from Docker Hub.
+
 ```eclipse/che-plugin-registry:latest``` image would be rebuilt after each commit in master
 
 ## OpenShift

--- a/check_plugins_viewer_mandatory_fields.sh
+++ b/check_plugins_viewer_mandatory_fields.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+FIELDS=("title" "publisher" "category" "icon" "description" "repository" "firstPublicationDate" "latestUpdateDate")
+CATEGORIES=("Editor" "Debugger" "Formatter" "Language" "Linter" "Snippet" "Theme" "Other")
+
+function check_category() {
+for CATEGORY in "${CATEGORIES[@]}"
+do
+  if [[ ${CATEGORY} == "$1" ]];then
+    return 0
+  fi
+done
+return 1
+}
+
+cd plugins || exit 1
+for d in */ ; do
+  ID_DIR_NAME=${d%/}
+  cd "$d" || exit 1
+
+  for VERSION_DIR_NAME in */ ; do
+    # Remove trailing slash
+    VERSION_DIR_NAME=${VERSION_DIR_NAME%/}
+    cd "${VERSION_DIR_NAME}" || exit 1
+
+    unset NULL_OR_EMPTY_FIELDS
+
+    for FIELD in "${FIELDS[@]}"
+    do
+      VALUE=$(yq r meta.yaml "$FIELD")
+      if [[ $VALUE == "null" || $VALUE = "\'\'" ]];then
+        # All fields are validated for not being null or empty, except for Category field:
+        # If the Category field is empty or null, then "Other" category will be set by default
+        # If the Category field has value, it should be matching the one from CATEGORIES array,
+        # or else it is invalid
+        if [[ "${FIELD}" == "category" ]];then
+          yq w meta.yaml category "Other" -i
+          VALUE=$(yq r meta.yaml "$FIELD")
+          if ! check_category "${VALUE}";then
+            echo "!!!   Invalid category in '${ID_DIR_NAME}/${VERSION_DIR_NAME}': $VALUE"
+            INVALID_FIELDS=true
+          fi
+          continue
+        fi
+        NULL_OR_EMPTY_FIELDS+="$FIELD "
+        continue
+      fi
+    done
+
+    if [[ -n "${NULL_OR_EMPTY_FIELDS}" ]];then
+      echo "!!!   Null or empty mandatory fields in '${ID_DIR_NAME}/${VERSION_DIR_NAME}': $NULL_OR_EMPTY_FIELDS"
+      INVALID_FIELDS=true
+    fi
+
+    cd .. || exit 1
+  done
+
+  cd .. || exit 1
+done
+
+if [[ -n "${INVALID_FIELDS}" ]];then
+  exit 1
+fi
+

--- a/cico_build.sh
+++ b/cico_build.sh
@@ -38,8 +38,9 @@ function install_deps() {
   /usr/sbin/setenforce 0  || true
 
   # Get all the deps in
-  yum -y install \
-    docker \
+  yum install -y yum-utils device-mapper-persistent-data lvm2
+  yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  yum install -y docker-ce \
     git
 
   service docker start

--- a/index.sh
+++ b/index.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2012-2018 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/plugins/che-dummy-plugin/0.0.1/meta.yaml
+++ b/plugins/che-dummy-plugin/0.0.1/meta.yaml
@@ -6,3 +6,5 @@ title: Che Samples Hello World Plugin
 description: A hello world theia plug-in wrapped into a Che Plug-in
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 url: https://github.com/ws-skeleton/che-dummy-plugin/releases/download/untagged-8f3e198285a2f3b6b2db/che-dummy-plugin.tar.gz
+publisher: Red Hat, Inc.
+repository: https://github.com/ws-skeleton/che-dummy-plugin/

--- a/plugins/che-machine-exec-plugin/0.0.1/meta.yaml
+++ b/plugins/che-machine-exec-plugin/0.0.1/meta.yaml
@@ -3,6 +3,9 @@ version: 0.0.1
 type: Che Plugin
 name: Che machine-exec Service
 title: Che machine-exec Service Plugin
-description: Che Plug-in with che-machine-exec service to provide creation terminal or tasks for Eclipse CHE workspace machines.
+description: Che Plug-in with che-machine-exec service to provide creation terminal
+  or tasks for Eclipse CHE workspace machines.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 url: https://github.com/ws-skeleton/che-machine-exec/releases/download/0.0.1alfa2/che-service-plugin.tar.gz
+publisher: Red Hat, Inc.
+repository: https://github.com/ws-skeleton/che-machine-exec/

--- a/plugins/che-service-plugin/0.0.1/meta.yaml
+++ b/plugins/che-service-plugin/0.0.1/meta.yaml
@@ -6,3 +6,5 @@ title: Che Samples REST API Sidecar Plugin
 description: Che Plug-in with Theia plug-in and container definition providing a service
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 url: https://github.com/ws-skeleton/che-service-plugin/releases/download/untagged-5c4c888ff2de8ae7a5e2/che-service-plugin.tar.gz
+publisher: Red Hat, Inc.
+repository: https://github.com/ws-skeleton/che-service-plugin/

--- a/plugins/org.eclipse.che.editor.dirigible/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.dirigible/1.0.0/meta.yaml
@@ -6,3 +6,6 @@ title: Eclipse Dirigible for Eclipse Che
 description: Eclipse Dirigible as App Development Platform for Eclipse Che
 icon: https://www.dirigible.io/img/dirigible.svg
 url: https://github.com/dirigiblelabs/dirigible-che-editor-plugin/releases/download/1.0.0/dirigible-che-editor-plugin.tar.gz
+publisher: Red Hat, Inc.
+category: Editor
+repository: https://github.com/dirigiblelabs/dirigible-che-editor-plugin/

--- a/plugins/org.eclipse.che.editor.eclipseide/0.0.1/meta.yaml
+++ b/plugins/org.eclipse.che.editor.eclipseide/0.0.1/meta.yaml
@@ -6,3 +6,6 @@ title: Eclipse IDE (in browser using Broadway) as editor for Eclipse Che
 description: Eclipse IDE
 icon: https://cdn.freebiesupply.com/logos/large/2x/eclipse-11-logo-svg-vector.svg
 url: https://github.com/ws-skeleton/che-editor-eclipseide/releases/download/0.0.1/che-editor-plugin.tar.gz
+publisher: Red Hat, Inc.
+category: Editor
+repository: https://github.com/ws-skeleton/che-editor-eclipseide/

--- a/plugins/org.eclipse.che.editor.gwt/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.gwt/1.0.0/meta.yaml
@@ -6,3 +6,6 @@ title: Eclipse GWT IDE for Eclipse Che
 description: Eclipse GWT IDE
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 url: https://github.com/eclipse/che-editor-gwt-ide/releases/download/che-editor-gwt-ide-2018-12-18_2212-00/che-editor-plugin.tar.gz
+publisher: Red Hat, Inc.
+category: Editor
+repository: https://github.com/eclipse/che-editor-gwt-ide/

--- a/plugins/org.eclipse.che.editor.jupyter/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.jupyter/1.0.0/meta.yaml
@@ -6,3 +6,6 @@ title: Jupyter Notebook as Editor for Eclipse Che
 description: Jupyter Notebook as Editor for Eclipse Che
 icon: https://jupyter.org/assets/main-logo.svg
 url: https://github.com/ws-skeleton/che-editor-jupyter/releases/download/untagged-cc4e4c9a7741551b6776/che-editor-plugin.tar.gz
+publisher: Red Hat, Inc.
+category: Editor
+repository: https://github.com/ws-skeleton/che-editor-jupyter/

--- a/plugins/org.eclipse.che.editor.theia/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.theia/1.0.0/meta.yaml
@@ -6,3 +6,6 @@ title: Eclipse Theia for Eclipse Che
 description: Eclipse Theia
 icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
 url: https://github.com/ws-skeleton/che-editor-theia/releases/download/untagged-2218dafda12e0786aa79/che-editor-plugin.tar.gz
+publisher: Red Hat, Inc.
+category: Editor
+repository: https://github.com/ws-skeleton/che-editor-theia/

--- a/plugins/org.eclipse.che.samples.container-fortune/0.0.1/meta.yaml
+++ b/plugins/org.eclipse.che.samples.container-fortune/0.0.1/meta.yaml
@@ -3,6 +3,9 @@ version: 0.0.1
 type: Theia plugin
 name: Che-Samples-Fortune
 title: Che Samples Container Fortune Plugin
-description: Fortune plug-in running in its own container that provides the fortune tool
+description: Fortune plug-in running in its own container that provides the fortune
+  tool
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 url: https://github.com/ws-skeleton/che-fortune-plugin/releases/download/untagged-bbffe2843692982f673b/che_fortune_plugin.theia
+publisher: Red Hat, Inc.
+repository: https://github.com/ws-skeleton/che-fortune-plugin/

--- a/plugins/org.eclipse.che.theia.dev/0.0.1/meta.yaml
+++ b/plugins/org.eclipse.che.theia.dev/0.0.1/meta.yaml
@@ -6,3 +6,5 @@ title: Che Theia Dev Plugin
 description: Che Theia Dev Plugin
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 url: https://github.com/che-incubator/che-theia-dev-plugin/releases/download/0.0.1/che-theia-dev-plugin.tar.gz
+publisher: Red Hat, Inc.
+repository: https://github.com/che-incubator/che-theia-dev-plugin/

--- a/set_plugin_dates.sh
+++ b/set_plugin_dates.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+cd plugins || exit 1
+for d in */ ; do
+  cd "$d" || exit 1
+
+  for VERSION_DIR_NAME in */ ; do
+    # Remove trailing slash
+    VERSION_DIR_NAME=${VERSION_DIR_NAME%/}
+    cd "${VERSION_DIR_NAME}" || exit 1
+
+    DATE=$(date -I)
+    yq w meta.yaml firstPublicationDate "${DATE}" -i || exit 1
+    yq w meta.yaml latestUpdateDate "${DATE}" -i || exit 1
+    cd ..
+  done
+
+  cd ..
+done


### PR DESCRIPTION
### What does this PR do?
Adds more fields to plugin's YAML

| Property | YAML  |
|---|---|
| Title | title |
| Publisher | publisher |
| Category | category |
| Icon | icon |
| Short-Description | description |
| Preview | preview | 
| Repository | repository
| First Publication Date | firstPublicationDate | 
| Latest Updated | latestUpdateDate |
| Tags | tags
| Media-img | media-img
| Media-video | media-video

Added script to validate presense of mandatory fields (to not be null or empty):
`title, publisher, category, icon, description, repository, firstPublicationDate, latestUpdateDate`

Field `category` is also validated, as it must have the value of one of the following 
"Editor", "Debugger", "Formatter", "Language", "Linter", "Snippet", "Theme", "Other"

Non mandatory fields are not validated at all

### What issue does this PR fix or reference
https://github.com/eclipse/che-plugin-registry/issues/71