### PR TITLE
WIP - Adds VSCode-YAML plugin

### DIFF
--- a/plugins/che-yaml-plugin/0.2.1/meta.yaml
+++ b/plugins/che-yaml-plugin/0.2.1/meta.yaml
@@ -8,3 +8,4 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 attributes:
   extension: "vscode:extension/redhat.vscode-yaml"
   container-image: "eclipse/che-theia"
+  containerImage: "eclipse/che-theia"

--- a/plugins/che-yaml-plugin/0.2.1/meta.yaml
+++ b/plugins/che-yaml-plugin/0.2.1/meta.yaml
@@ -7,4 +7,4 @@ description: YAML Language Support by Red Hat, with built-in Kubernetes and Kedg
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 attributes:
   extension: "vscode:extension/redhat.vscode-yaml"
-  container-image: "eclipse/che-theia" 
+  container-image: "eclipse/che-theia"

--- a/plugins/che-yaml-plugin/0.2.1/meta.yaml
+++ b/plugins/che-yaml-plugin/0.2.1/meta.yaml
@@ -1,0 +1,10 @@
+id: che-yaml-plugin
+version: 0.2.1
+type: VS Code extension
+name: Che YAML Plugin
+title: Che YAML Plugin
+description: YAML Language Support by Red Hat, with built-in Kubernetes and Kedge syntax support
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+attributes:
+  extension: "vscode:extension/redhat.vscode-yaml"
+  container-image: "jpinkney/che7-yaml" 

--- a/plugins/che-yaml-plugin/0.2.1/meta.yaml
+++ b/plugins/che-yaml-plugin/0.2.1/meta.yaml
@@ -7,5 +7,5 @@ description: YAML Language Support by Red Hat, with built-in Kubernetes and Kedg
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 attributes:
   extension: "vscode:extension/redhat.vscode-yaml"
-  container-image: "eclipse/che-theia"
-  containerImage: "eclipse/che-theia"
+  container-image: "jpinkney/che7-yaml"
+  containerImage: "jpinkney/che7-yaml"

--- a/plugins/che-yaml-plugin/0.2.1/meta.yaml
+++ b/plugins/che-yaml-plugin/0.2.1/meta.yaml
@@ -7,4 +7,4 @@ description: YAML Language Support by Red Hat, with built-in Kubernetes and Kedg
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 attributes:
   extension: "vscode:extension/redhat.vscode-yaml"
-  container-image: "jpinkney/che7-yaml" 
+  container-image: "eclipse/che-theia" 


### PR DESCRIPTION
### What does this PR do?

This PR adds the [VSCode-YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) plugin. 

The dockerfile for "jpinkney/che7-yaml" lives [here](https://github.com/JPinkney/Che7-YAML/blob/master/Dockerfile) though I'm not sure if we even need it and can just use the "wsskeleton/theia-endpoint-runtime" image.

Tested and working on che.openshift.io. However, only a subset of the features are working (documented [here](https://github.com/eclipse/che/issues/12142#issuecomment-452046280)).