### PR TITLE
Parametarize `kubernetes.io/ingress.class`

### DIFF
--- a/kubernetes/che-plugin-registry/templates/ingress.yaml
+++ b/kubernetes/che-plugin-registry/templates/ingress.yaml
@@ -12,7 +12,7 @@ kind: Ingress
 metadata:
   name: che-plugin-registry
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class }}
 spec:
   rules:
   - host: {{ printf "che-plugin-registry-%s.%s" .Release.Namespace .Values.global.ingressDomain }}

--- a/kubernetes/che-plugin-registry/values.yaml
+++ b/kubernetes/che-plugin-registry/values.yaml
@@ -13,3 +13,5 @@ chePluginRegistryMemoryLimit: 256Mi
 
 global:
   ingressDomain: 192.168.99.100.nip.io
+  ingress:
+    class: 'nginx'


### PR DESCRIPTION
### What does this PR do?

Enable to customize the value of `kubernetes.io/ingress.class`.
This is related on eclipse/che#12645 and similar to eclipse/che#11820