### PR TITLE
[Helm deployments] Enable TLS on the ingress.

### DIFF
--- a/kubernetes/che-plugin-registry/templates/ingress.yaml
+++ b/kubernetes/che-plugin-registry/templates/ingress.yaml
@@ -22,3 +22,9 @@ spec:
         backend:
           serviceName: che-plugin-registry
           servicePort: 8080
+{{- if .Values.chePluginRegistryIngressSecretName }}
+    tls:
+    - hosts:
+      - {{ printf "che-plugin-registry-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
+      secretName: {{ .Values.chePluginRegistryIngressSecretName }}
+{{- end -}}

--- a/kubernetes/che-plugin-registry/values.yaml
+++ b/kubernetes/che-plugin-registry/values.yaml
@@ -10,6 +10,7 @@
 chePluginRegistryImage: eclipse/che-plugin-registry
 chePluginRegistryImagePullPolicy: Always
 chePluginRegistryMemoryLimit: 256Mi
+#chePluginRegistryIngressSecretName: che-tls
 
 global:
   ingressDomain: 192.168.99.100.nip.io


### PR DESCRIPTION
### What does this PR do?

Appends `tls:` object to the ingress if the secret name was specified.