### PR TITLE
Change the name of Java LS plugin

### DIFF
--- a/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
+++ b/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
@@ -1,8 +1,8 @@
 id: org.eclipse.che.vscode-redhat.java
 version: 0.38.0
 type: VS Code extension
-name: Java Language Server
-title: Language Support for Java
+name: Language Support for Java(TM)
+title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 url: https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

### What does this PR do?
Changes the name and title in `org.eclipse.che.vscode-redhat.java` plugin.
Copied it from https://marketplace.visualstudio.com/items?itemName=redhat.java