### PR TITLE
 Introduce 'next' Theia plugin version

### DIFF
--- a/plugins/org.eclipse.che.editor.theia/1.0.0/meta.yaml
+++ b/plugins/org.eclipse.che.editor.theia/1.0.0/meta.yaml
@@ -5,7 +5,7 @@ name: theia-ide
 title: Eclipse Theia for Eclipse Che
 description: Eclipse Theia
 icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
-url: https://github.com/eclipse/che-theia/releases/download/v0.3.19/che-editor-plugin.tar.gz
+url: https://github.com/eclipse/che-theia/releases/download/v0.4.0/che-editor-plugin.tar.gz
 publisher: Red Hat, Inc.
 category: Editor
 repository: https://github.com/eclipse/che-theia

--- a/plugins/org.eclipse.che.editor.theia/next/meta.yaml
+++ b/plugins/org.eclipse.che.editor.theia/next/meta.yaml
@@ -2,12 +2,12 @@ id: org.eclipse.che.editor.theia
 version: master
 type: Che Editor
 name: theia-ide
-title: Eclipse Theia development version. Deprecated, please use 'next' version
-description: Eclipse Theia, get the latest release each day.  Deprecated, please use 'next' version
+title: Eclipse Theia development version.
+description: Eclipse Theia, get the latest release each day.
 icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
 url: https://github.com/eclipse/che-theia/releases/download/next/che-editor-plugin.tar.gz
 publisher: Red Hat, Inc.
 category: Editor
 repository: https://github.com/eclipse/che-theia
-firstPublicationDate: "2019-02-12"
+firstPublicationDate: "2019-03-07"
 

--- a/plugins/org.eclipse.che.editor.theia/next/meta.yaml
+++ b/plugins/org.eclipse.che.editor.theia/next/meta.yaml
@@ -1,5 +1,5 @@
 id: org.eclipse.che.editor.theia
-version: master
+version: next
 type: Che Editor
 name: theia-ide
 title: Eclipse Theia development version.


### PR DESCRIPTION
### What does this PR do?
- Introduce 'next' Theia plugin version
- Use `latest` stable Theia version(0.4.0) for `1.0.0`
- Deprecate `master` version(should be removed in a few weeks)

Issue eclipse/che-theia#63
