### PR TITLE
Update Python sidecar image version

### DIFF
--- a/plugins/ms-python.python/2019.2.5433/meta.yaml
+++ b/plugins/ms-python.python/2019.2.5433/meta.yaml
@@ -11,4 +11,4 @@ repository: https://github.com/Microsoft/vscode-python
 category: Language
 firstPublicationDate: "2019-03-05"
 attributes:
-  containerImage: "eclipse/che-remote-plugin-python-3.7.2:next"
+  containerImage: "eclipse/che-remote-plugin-python-3.7.3:next"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### What does this PR do?

Python 3.7.3 is going to be used in a dev image for the Python stack [1]
It is logically to have the same Python version and in a sidecar container for the python plugin.

[1] https://github.com/eclipse/che/issues/12944