### PR TITLE
che #12840: Changing url of vscode xml plugin from marketplace to github release

### DIFF
--- a/plugins/redhat.vscode-xml/0.3.0/meta.yaml
+++ b/plugins/redhat.vscode-xml/0.3.0/meta.yaml
@@ -4,7 +4,7 @@ type: VS Code extension
 name: XML
 title: XML Language Support by Red Hat
 description: This VS Code extension provides support for creating and editing XML documents, based on the LSP4XML language server, running with Java.
-url: https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/vscode-xml/0.3.0/vspackage
+url: https://github.com/redhat-developer/vscode-xml/releases/download/0.3.0/redhat.vscode-xml-0.3.0.vsix
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/redhat-developer/vscode-xml


### PR DESCRIPTION
### What does this PR do?
Chaning url of vscode xml plugin from marketplace to git
https://github.com/redhat-developer/rh-che/issues/1300