### PR TITLE
che #12840 Adding latest versions of yaml (0.4.0) and xml (0.5.1) vscode plugins

### DIFF
--- a/plugins/redhat.vscode-xml/0.5.1/meta.yaml
+++ b/plugins/redhat.vscode-xml/0.5.1/meta.yaml
@@ -9,6 +9,6 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/redhat-developer/vscode-xml
 category: Language
-firstPublicationDate: "2019-02-20"
+firstPublicationDate: "2019-04-19"
 attributes:
   containerImage: "eclipse/che-remote-plugin-runner-java8:next"

--- a/plugins/redhat.vscode-xml/0.5.1/meta.yaml
+++ b/plugins/redhat.vscode-xml/0.5.1/meta.yaml
@@ -1,0 +1,14 @@
+id: redhat.vscode-xml
+version: 0.5.1
+type: VS Code extension
+name: XML
+title: XML Language Support by Red Hat
+description: This VS Code extension provides support for creating and editing XML documents, based on the LSP4XML language server, running with Java.
+url: https://github.com/redhat-developer/vscode-xml/releases/download/0.5.1/redhat.vscode-xml-0.5.1.vsix
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+publisher: Red Hat, Inc.
+repository: https://github.com/redhat-developer/vscode-xml
+category: Language
+firstPublicationDate: "2019-02-20"
+attributes:
+  containerImage: "eclipse/che-remote-plugin-runner-java8:next"

--- a/plugins/redhat.vscode-yaml/0.4.0/meta.yaml
+++ b/plugins/redhat.vscode-yaml/0.4.0/meta.yaml
@@ -9,6 +9,6 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/redhat-developer/vscode-yaml
 category: Language
-firstPublicationDate: "2019-02-20"
+firstPublicationDate: "2019-04-19"
 attributes:
   containerImage: "eclipse/che-theia-endpoint-runtime:next"

--- a/plugins/redhat.vscode-yaml/0.4.0/meta.yaml
+++ b/plugins/redhat.vscode-yaml/0.4.0/meta.yaml
@@ -1,0 +1,14 @@
+id: redhat.vscode-yaml
+version: 0.4.0
+type: VS Code extension
+name: YAML
+title: YAML Language Support by Red Hat, with built-in Kubernetes and Kedge syntax support
+description: Provides comprehensive YAML Language support to Visual Studio Code, via the yaml-language-server, with built-in Kubernetes and Kedge syntax support.
+url: https://github.com/redhat-developer/vscode-yaml/releases/download/0.4.0/redhat.vscode-yaml-0.4.0.vsix
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+publisher: Red Hat, Inc.
+repository: https://github.com/redhat-developer/vscode-yaml
+category: Language
+firstPublicationDate: "2019-02-20"
+attributes:
+  containerImage: "eclipse/che-theia-endpoint-runtime:next"


### PR DESCRIPTION
che #12840 Adding latest versions of yaml (0.4.0) and xml (0.5.1) vscode plugins
Also contains workaround for marketplace rate limmit error - https://github.com/eclipse/che/issues/12840