### PR TITLE
che #12840 Adding latest version of openshift-connector plugin. Switching plugin download url from marketplace to github release

### DIFF
--- a/plugins/redhat.vscode-openshift-connector/0.0.19/meta.yaml
+++ b/plugins/redhat.vscode-openshift-connector/0.0.19/meta.yaml
@@ -1,14 +1,14 @@
 id: redhat.vscode-openshift-connector
-version: 0.0.17
+version: 0.0.19
 type: VS Code extension
 name: OpenShift Connector
 title: OpenShift Connector
 description: Interacting with Red Hat OpenShift clusters and providing a streamlined developer experience using Eclipse Che
-url: https://github.com/redhat-developer/vscode-openshift-tools/releases/download/v0.0.17/openshift-connector-0.0.17-127.vsix
+url: https://github.com/redhat-developer/vscode-openshift-tools/releases/download/v0.0.19/openshift-connector-0.0.19-183.vsix
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/redhat-developer/vscode-openshift-tools
 category: Other
-firstPublicationDate: "2019-03-11"
+firstPublicationDate: "2019-04-19"
 attributes:
   containerImage: "eclipse/che-remote-plugin-openshift-connector-0.0.17:next"


### PR DESCRIPTION
### What does this PR do?
Adding latest version of openshift-connector plugin. Switching plugin download url from marketplace to github release

workaround for https://github.com/eclipse/che/issues/12840