### PR TITLE
che #12840 Downloading sonarlint extention directly from the github release page

### DIFF
--- a/plugins/org.eclipse.che.vscode-sonarlint/0.0.1/meta.yaml
+++ b/plugins/org.eclipse.che.vscode-sonarlint/0.0.1/meta.yaml
@@ -5,11 +5,11 @@ name: vscode-sonarlint
 title: Sonarlint code intelligence
 description: VS Code extension that provides sonarlint features
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-attributes:
-  extension: "vscode:extension/SonarSource.sonarlint-vscode"
-  container-image: "garagatyi/remotetheia:java"
-  containerImage: "garagatyi/remotetheia:java"
+url: https://github.com/SonarSource/sonarlint-vscode/releases/download/1.6.0/sonarlint-vscode-1.6.0.vsix
 firstPublicationDate: "2019-02-05"
 category: Linter
 publisher: SonarSource
 repository: https://www.sonarlint.org/
+attributes:
+  container-image: "garagatyi/remotetheia:java"
+  containerImage: "garagatyi/remotetheia:java"


### PR DESCRIPTION
Workaround for https://github.com/eclipse/che/issues/12840
There is an inconsistency between version of extention in registry (0.0.1) and actual release (1.6.0), but we could probably treat it as a minor issue that should be tackled for the upcoming releases of the extention in the plugin registry future.