### PR TITLE
che #12840 Adding the latest version of python plugin. Downloading vscode extention directly from the github release page to avoid marketplace rate limmit issue

### DIFF
--- a/plugins/ms-python.python/2019.3.6558/meta.yaml
+++ b/plugins/ms-python.python/2019.3.6558/meta.yaml
@@ -1,0 +1,14 @@
+id: ms-python.python
+version: 2019.3.6558
+type: VS Code extension
+name: Python
+title: Python extension
+description: Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, and more.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+url: https://github.com/Microsoft/vscode-python/releases/download/2019.3.6558/ms-python-release.vsix
+publisher: Red Hat, Inc.
+repository: https://github.com/Microsoft/vscode-python
+category: Language
+firstPublicationDate: "2019-04-23"
+attributes:
+  containerImage: "eclipse/che-remote-plugin-python-3.7.3:next"


### PR DESCRIPTION
### What does this PR do?
Adding the latest version of python plugin. Downloading vscode extention directly from the github release page to avoid marketplace rate limit issue - https://github.com/eclipse/che/issues/12840

NOTE: I also wanted to update existing `2019.2.5433` version and download `vsix` directly from github, but for some reason this version does not exist https://github.com/Microsoft/vscode-python/releases/


