### PR TITLE
Add Java Debugger into Java plugin

### DIFF
--- a/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
+++ b/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
@@ -3,7 +3,7 @@ version: 0.38.0
 type: VS Code extension
 name: Language Support for Java(TM)
 title: Language Support for Java(TM) by Red Hat
-description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
+description: Java Linting, Intellisense, formatting, refactoring, debug, Maven/Gradle support and more...
 extensions:
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-debug/0.16.0/vspackage
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage

--- a/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
+++ b/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
@@ -5,7 +5,7 @@ name: Language Support for Java(TM)
 title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 extensions:
-  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-debug/0.17.0/vspackage
+  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-debug/0.16.0/vspackage
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.41.0/vspackage
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.

--- a/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
+++ b/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
@@ -6,7 +6,7 @@ title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, debug, Maven/Gradle support and more...
 extensions:
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-debug/0.16.0/vspackage
-  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage
+  - https://github.com/redhat-developer/vscode-java/releases/download/v0.38.0/redhat.java-0.38.0.vsix
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/redhat-developer/vscode-java

--- a/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
+++ b/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
@@ -4,7 +4,9 @@ type: VS Code extension
 name: Language Support for Java(TM)
 title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
-url: https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage
+extensions:
+  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-debug/0.17.0/vspackage
+  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/redhat-developer/vscode-java

--- a/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
+++ b/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
@@ -6,7 +6,7 @@ title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 extensions:
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-debug/0.16.0/vspackage
-  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.41.0/vspackage
+  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/redhat-developer/vscode-java

--- a/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
+++ b/plugins/org.eclipse.che.vscode-redhat.java/0.38.0/meta.yaml
@@ -6,7 +6,7 @@ title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 extensions:
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-debug/0.17.0/vspackage
-  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.38.0/vspackage
+  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/0.41.0/vspackage
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/redhat-developer/vscode-java


### PR DESCRIPTION
### What does this PR do?
Adds [vscode-java-debug](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) into Che remote java plugin.
Unfortunately https://github.com/Microsoft/vscode-java-debug doesn't have `vsx` files in releases, so, we have to download it from VS Marketplace.