### PR TITLE
Downloading `vsix` for kubernetes tools extention from GH release in order to avoid marketplace rate limit error

### DIFF
--- a/plugins/ms-kubernetes-tools.vscode-kubernetes-tools/0.1.17/meta.yaml
+++ b/plugins/ms-kubernetes-tools.vscode-kubernetes-tools/0.1.17/meta.yaml
@@ -4,7 +4,7 @@ type: VS Code extension
 name: Kubernetes
 title: Kubernetes Tools
 description: Develop, deploy and debug Kubernetes applications
-url: https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-kubernetes-tools/vsextensions/vscode-kubernetes-tools/0.1.17/vspackage
+url: https://github.com/Azure/vscode-kubernetes-tools/releases/download/0.1.17/vscode-kubernetes-tools-0.1.17.vsix
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 publisher: Red Hat, Inc.
 repository: https://github.com/Azure/vscode-kubernetes-tools


### PR DESCRIPTION
### What does this PR do?
Downloading `vsix` for kubernetes tools extention from GH release in order to avoid marketplace rate limit error - https://github.com/eclipse/che/issues/12840
