### PR TITLE
Using GH release instead of marketplace for go extension to avoid marketplace rate limit issues

### DIFF
--- a/plugins/ms-vscode.go/0.9.2/meta.yaml
+++ b/plugins/ms-vscode.go/0.9.2/meta.yaml
@@ -5,7 +5,7 @@ name: Go
 title: Rich Go language support
 description: This extension adds rich language support for the Go language
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-url: https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/Go/0.9.2/vspackage
+url: https://github.com/Microsoft/vscode-go/releases/download/0.9.2/Go-0.9.2.vsix
 publisher: Red Hat, Inc.
 repository: https://github.com/Microsoft/vscode-go.git
 category: Language

--- a/v2/plugins/ms-vscode/go/0.9.2/meta.yaml
+++ b/v2/plugins/ms-vscode/go/0.9.2/meta.yaml
@@ -6,7 +6,7 @@ displayName: Go
 title: Rich Go language support
 description: This extension adds rich language support for the Go language
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-url: https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/Go/0.9.2/vspackage
+url: https://github.com/Microsoft/vscode-go/releases/download/0.9.2/Go-0.9.2.vsix
 repository: https://github.com/Microsoft/vscode-go.git
 category: Language
 firstPublicationDate: "2019-02-21"


### PR DESCRIPTION
### What does this PR do?
Related issue - https://github.com/eclipse/che/issues/12840
