### PR TITLE
 Fixing build for promototion to dsaas-stg. Adding build status of the main CI job https://ci.centos.org/job/devtools-che-plugin-registry-build-master

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -12,8 +12,8 @@ COPY .htaccess README.md *.sh /build/
 COPY /plugins /build/plugins
 COPY /v2 /build/v2
 WORKDIR /build/
-RUN cd plugins && ./check_plugins_location_v1.sh
-RUN cd v2/plugins && ./check_plugins_location_v2.sh
+RUN ./check_plugins_location_v1.sh
+RUN ./check_plugins_location_v2.sh
 RUN ./check_plugins_images.sh
 RUN ./set_plugin_dates.sh
 RUN ./check_plugins_viewer_mandatory_fields_v1.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/eclipse/che-plugin-registry.svg?style=svg)](https://circleci.com/gh/eclipse/che-plugin-registry)
+[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-plugin-registry-build-master/)](https://ci.centos.org/job/devtools-che-plugin-registry-build-master/)
 
 # Eclipse Che plugin registry
 


### PR DESCRIPTION
Adding build status of the main CI job https://ci.centos.org/job/devtools-che-plugin-registry-build-master 

Currently failing with:

> [91m/bin/sh: ./check_plugins_location_v1.sh: not found
> [0mThe command '/bin/sh -c cd plugins && ./check_plugins_location_v1.sh' returned a non-zero code: 127