### PR TITLE
Che 7 plugin: PHP Debugger #12795

### DIFF
--- a/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
+++ b/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+publisher: redhat
+name: php-debugger
+version: 1.13.0
+displayName: PHP Debugger
+title: PHP Debugger
+type: VS Code extension
+description: This VS Code extension provides support for PHP debugging, based on the PHP Debug extension from Felix Backer.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/felixfbecker/vscode-php-debug
+category: Language
+firstPublicationDate: "2019-04-16"
+spec:
+  containers:
+    - image: "eclipse/che-remote-plugin-php7:next"
+  extensions:
+    - https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix

--- a/v3/plugins/redhat/php-debugger/latest/meta.yaml
+++ b/v3/plugins/redhat/php-debugger/latest/meta.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+publisher: redhat
+name: php-debugger
+version: latest
+displayName: PHP Debugger
+title: PHP Debugger
+type: VS Code extension
+description: This VS Code extension provides support for PHP debugging, based on the PHP Debug extension from Felix Backer.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/felixfbecker/vscode-php-debug
+category: Language
+firstPublicationDate: "2019-04-16"
+spec:
+  containers:
+    - image: "eclipse/che-remote-plugin-php7:next"
+  extensions:
+    - https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix


### PR DESCRIPTION
Add PHP Debug v.1.13.0 for PHP Debugger
From https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

### What does this PR do?

This PR adds a Che7 plugin for PHP Debugger based on PHP-Debug VSCode extension from Felix Backer: https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug

Fixes https://github.com/eclipse/che/issues/12795