### PR TITLE
Che 7 plugin: PHP Language Server #12797

### DIFF
--- a/v3/plugins/redhat/php/1.0.13/meta.yaml
+++ b/v3/plugins/redhat/php/1.0.13/meta.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+publisher: redhat
+name: php
+version: 1.0.13
+displayName: PHP Intelephense
+title: PHP Intelephense
+description: This VS Code extension provides support for creating and editing PHP documents, based on the PHP Intelephense language server.
+type: VS Code extension
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/bmewburn/vscode-intelephense
+category: Language
+firstPublicationDate: "2019-04-16"
+spec:
+  containers:
+    - image: "eclipse/che-remote-plugin-php7:next"
+  extensions:
+    - https://github.com/che-incubator/vscode-intelephense/releases/download/v1.0.13/bmewburn.vscode-intelephense-client-1.0.13.vsix

--- a/v3/plugins/redhat/php/latest/meta.yaml
+++ b/v3/plugins/redhat/php/latest/meta.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+publisher: redhat
+name: php
+version: latest
+displayName: PHP Intelephense
+title: PHP Intelephense
+description: This VS Code extension provides support for creating and editing PHP documents, based on the PHP Intelephense language server.
+type: VS Code extension
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/bmewburn/vscode-intelephense
+category: Language
+firstPublicationDate: "2019-04-16"
+spec:
+  containers:
+    - image: "eclipse/che-remote-plugin-php7:next"
+  extensions:
+    - https://github.com/che-incubator/vscode-intelephense/releases/download/v1.0.13/bmewburn.vscode-intelephense-client-1.0.13.vsix


### PR DESCRIPTION
Add PHP Intelephense v.1.0.13 for PHP Landuage Support
From https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

### What does this PR do?

This PR adds a Che7 plugin for PHP Language support based on PHPIntelephense VSCode extension: https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client

Fixes eclipse/che#12797