### PR TITLE
Add Kubernetes Tooling Che Plugin based on the latest VS Code Kubernetes extension - 1.0.0

### DIFF
--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/README.md
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/README.md
@@ -1,0 +1,11 @@
+# Eclipse Che Kubernetes Tooling Plugin
+
+## Setting up the access to a cluster from a Che Workspace
+
+The Plugin relies on `kubectl` to communicate with a Kubernetes cluster. The access to a cluster should be set up through a `kubeconfig`.
+
+`chectl` provides the [command](https://github.com/che-incubator/chectl#chectl-workspaceinject) that simplifies injecting local `kubeconfig` into a Che Workspace. When your Workspace is running, call the following command:
+```shell
+chectl workspace:inject -k
+```
+Then reload a browsers page to refresh the `Clusters` tree.

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+publisher: ms-kubernetes-tools
+name: vscode-kubernetes-tools
+version: 1.0.0
+type: VS Code extension
+displayName: Kubernetes
+title: Kubernetes Tools
+description: Develop, deploy and debug Kubernetes applications
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/Azure/vscode-kubernetes-tools
+category: Other
+firstPublicationDate: "2019-05-15"
+spec:
+  containers:
+    - image: "eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:next"
+  extensions:
+    - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.0/vscode-kubernetes-tools-1.0.0.vsix


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
Adds Kubernetes Tooling Che Plugin which is based on the latest [VS Code Kubernetes extension](https://github.com/Azure/vscode-kubernetes-tools/) - 1.0.0. Also, the plugin is running in a sidecar from `eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:next` image that allows using [Buildah](https://github.com/containers/buildah) as an image builder instead of Docker daemon.

The PR should be merged once https://github.com/eclipse/che-theia/pull/220 is merged.