### PR TITLE
Adds Dependency Analytics Plugin v3

### DIFF
--- a/v3/plugins/redhat/dependency-analytics/0.0.12/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/0.0.12/meta.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+publisher: redhat
+name: dependency-analytics
+version: 0.0.12
+type: VS Code extension
+displayName: Dependency Analytics
+title: Insights about your application dependencies
+description: Insights about your application dependencies, Security, License compatibility and AI based guidance to choose appropriate dependencies for your application.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension
+category: Other
+firstPublicationDate: '2018-10-03'
+spec:
+  containers:
+    - image: eclipse/che-remote-plugin-dependency-analytics-0.0.12:7.0.0-next
+      memoryLimit: "512Mi"
+  extensions:
+    - https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.0.12/redhat.fabric8-analytics-0.0.12.vsix

--- a/v3/plugins/redhat/dependency-analytics/latest/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/latest/meta.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+publisher: redhat
+name: dependency-analytics
+version: latest
+type: VS Code extension
+displayName: Dependency Analytics
+title: Insights about your application dependencies
+description: Insights about your application dependencies, Security, License compatibility and AI based guidance to choose appropriate dependencies for your application.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension
+category: Other
+firstPublicationDate: '2018-10-03'
+spec:
+  containers:
+    - image: eclipse/che-remote-plugin-dependency-analytics-0.0.12:7.0.0-next
+      memoryLimit: "512Mi"
+  extensions:
+    - https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.0.12/redhat.fabric8-analytics-0.0.12.vsix


### PR DESCRIPTION
### What does this PR do?

Adds meta information for [Dependency Analytics](https://marketplace.visualstudio.com/items?itemName=redhat.fabric8-analytics) Che Plugin v0.0.12/latest

What issues does this PR fix or reference?

https://github.com/redhat-developer/rh-che/issues/1045

### Dependent PR : 
- https://github.com/eclipse/che-theia/pull/297