### PR TITLE
Decrease default memory for Che Theia IDE to 512M

### DIFF
--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -66,4 +66,4 @@ spec:
          - exposedPort: 13131
          - exposedPort: 13132
          - exposedPort: 13133
-     memoryLimit: "1536M"
+     memoryLimit: "512M"


### PR DESCRIPTION
### What does this PR do?
This PR decreases default memory for Che Theia IDE to 512M.
512M is a value suggested in [https://github.com/eclipse/che/issues/12620](https://github.com/eclipse/che/issues/12620)#`Memory_settings`.