### PR TITLE
Increase mem. limit for a Kubernetes Che Plugin sidecar to 1G

### DIFF
--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
@@ -13,5 +13,6 @@ firstPublicationDate: "2019-05-15"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:next"
+      memoryLimit: "1G"
   extensions:
     - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.0/vscode-kubernetes-tools-1.0.0.vsix


### PR DESCRIPTION
### What does this PR do?
Increases memory limit for a Kubernetes Che Plugin sidecar to 1G.
The amount of memory has been determined experimentally. Less memory causes unstable work of Helm Repos tree.