### PR TITLE
Set memory limit for php-intelephense plugin

### DIFF
--- a/v3/plugins/redhat/php/1.0.13/meta.yaml
+++ b/v3/plugins/redhat/php/1.0.13/meta.yaml
@@ -13,5 +13,6 @@ firstPublicationDate: "2019-04-16"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-php7:next"
+      memoryLimit: "1500Mi"
   extensions:
     - https://github.com/che-incubator/vscode-intelephense/releases/download/v1.0.13/bmewburn.vscode-intelephense-client-1.0.13.vsix

--- a/v3/plugins/redhat/php/1.0.13/meta.yaml
+++ b/v3/plugins/redhat/php/1.0.13/meta.yaml
@@ -13,6 +13,6 @@ firstPublicationDate: "2019-04-16"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-php7:next"
-      memoryLimit: "1500Mi"
+      memoryLimit: "1000Mi"
   extensions:
     - https://github.com/che-incubator/vscode-intelephense/releases/download/v1.0.13/bmewburn.vscode-intelephense-client-1.0.13.vsix

--- a/v3/plugins/redhat/php/latest/meta.yaml
+++ b/v3/plugins/redhat/php/latest/meta.yaml
@@ -13,5 +13,6 @@ firstPublicationDate: "2019-04-16"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-php7:next"
+      memoryLimit: "1500Mi"
   extensions:
     - https://github.com/che-incubator/vscode-intelephense/releases/download/v1.0.13/bmewburn.vscode-intelephense-client-1.0.13.vsix

--- a/v3/plugins/redhat/php/latest/meta.yaml
+++ b/v3/plugins/redhat/php/latest/meta.yaml
@@ -13,6 +13,6 @@ firstPublicationDate: "2019-04-16"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-php7:next"
-      memoryLimit: "1500Mi"
+      memoryLimit: "1000Mi"
   extensions:
     - https://github.com/che-incubator/vscode-intelephense/releases/download/v1.0.13/bmewburn.vscode-intelephense-client-1.0.13.vsix


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

### What does this PR do?
Set 1000Mi  as memory limit for php-intelephense plugin

### Related issue
https://github.com/eclipse/che/issues/13307