### PR TITLE
Use eclipse/che-remote-plugin-runner-java11 image for java based plugins

### DIFF
--- a/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
+++ b/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
@@ -12,6 +12,6 @@ category: Language
 firstPublicationDate: "2018-04-23"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:next"
+    - image: "eclipse/che-remote-plugin-runner-java11:next"
   extensions:
     - https://github.com/camel-tooling/camel-lsp-client-vscode/releases/download/0.0.14/camel-tooling.vscode-apache-camel-0.0.14.vsix

--- a/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
+++ b/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
@@ -13,5 +13,6 @@ firstPublicationDate: "2018-04-23"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-runner-java11:next"
+      memoryLimit: "512Mi"
   extensions:
     - https://github.com/camel-tooling/camel-lsp-client-vscode/releases/download/0.0.14/camel-tooling.vscode-apache-camel-0.0.14.vsix

--- a/v3/plugins/camel-tooling/vscode-apache-camel/latest/meta.yaml
+++ b/v3/plugins/camel-tooling/vscode-apache-camel/latest/meta.yaml
@@ -13,5 +13,6 @@ firstPublicationDate: '2018-04-23'
 spec:
   containers:
   - image: eclipse/che-remote-plugin-runner-java11:next
+    memoryLimit: "512Mi"
   extensions:
   - https://github.com/camel-tooling/camel-lsp-client-vscode/releases/download/0.0.14/camel-tooling.vscode-apache-camel-0.0.14.vsix

--- a/v3/plugins/camel-tooling/vscode-apache-camel/latest/meta.yaml
+++ b/v3/plugins/camel-tooling/vscode-apache-camel/latest/meta.yaml
@@ -12,6 +12,6 @@ category: Language
 firstPublicationDate: '2018-04-23'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java8:next
+  - image: eclipse/che-remote-plugin-runner-java11:next
   extensions:
   - https://github.com/camel-tooling/camel-lsp-client-vscode/releases/download/0.0.14/camel-tooling.vscode-apache-camel-0.0.14.vsix

--- a/v3/plugins/redhat/java/0.38.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.38.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:next"
+    - image: "eclipse/che-remote-plugin-runner-java11:next"
   extensions:
     - https://github.com/microsoft/vscode-java-debug/releases/download/0.16.0/vscode-java-debug-0.16.0.vsix
     - http://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.38.0-1373.vsix

--- a/v3/plugins/redhat/java/0.43.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.43.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-25"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:next"
+    - image: "eclipse/che-remote-plugin-runner-java11:next"
   extensions:
     - https://github.com/microsoft/vscode-java-debug/releases/download/0.16.0/vscode-java-debug-0.16.0.vsix
     - http://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.43.0-1473.vsix

--- a/v3/plugins/redhat/java/0.45.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.45.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-05-27"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:next"
+    - image: "eclipse/che-remote-plugin-runner-java11:next"
       memoryLimit: "1500Mi"
   extensions:
     - https://github.com/microsoft/vscode-java-debug/releases/download/0.16.0/vscode-java-debug-0.16.0.vsix

--- a/v3/plugins/redhat/java/latest/meta.yaml
+++ b/v3/plugins/redhat/java/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: '2019-05-27'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java8:next
+  - image: eclipse/che-remote-plugin-runner-java11:next
     memoryLimit: "1500Mi"
   extensions:
   - https://github.com/microsoft/vscode-java-debug/releases/download/0.16.0/vscode-java-debug-0.16.0.vsix

--- a/v3/plugins/redhat/vscode-xml/0.3.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.3.0/meta.yaml
@@ -12,6 +12,6 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:next"
+    - image: "eclipse/che-remote-plugin-runner-java11:next"
   extensions:
     - https://github.com/redhat-developer/vscode-xml/releases/download/0.3.0/redhat.vscode-xml-0.3.0.vsix

--- a/v3/plugins/redhat/vscode-xml/0.5.1/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.5.1/meta.yaml
@@ -12,6 +12,6 @@ category: Language
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:next"
+    - image: "eclipse/che-remote-plugin-runner-java11:next"
   extensions:
     - https://github.com/redhat-developer/vscode-xml/releases/download/0.5.1/redhat.vscode-xml-0.5.1.vsix

--- a/v3/plugins/redhat/vscode-xml/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/latest/meta.yaml
@@ -13,6 +13,6 @@ category: Language
 firstPublicationDate: '2019-04-19'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java8:next
+  - image: eclipse/che-remote-plugin-runner-java11:next
   extensions:
   - https://github.com/redhat-developer/vscode-xml/releases/download/0.5.1/redhat.vscode-xml-0.5.1.vsix

--- a/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
@@ -12,6 +12,6 @@ category: Linter
 repository: https://www.sonarlint.org/
 spec:
   containers:
-    - image: "garagatyi/remotetheia:java"
+    - image: "eclipse/che-remote-plugin-runner-java11:next"
   extensions:
     - https://github.com/SonarSource/sonarlint-vscode/releases/download/1.6.0/sonarlint-vscode-1.6.0.vsix

--- a/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
@@ -12,6 +12,6 @@ category: Linter
 repository: https://www.sonarlint.org/
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:next"
+    - image: "eclipse/che-remote-plugin-runner-java8:next"
   extensions:
     - https://github.com/SonarSource/sonarlint-vscode/releases/download/1.6.0/sonarlint-vscode-1.6.0.vsix

--- a/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
@@ -13,5 +13,6 @@ repository: https://www.sonarlint.org/
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-runner-java8:next"
+      memoryLimit: "512Mi"
   extensions:
     - https://github.com/SonarSource/sonarlint-vscode/releases/download/1.6.0/sonarlint-vscode-1.6.0.vsix

--- a/v3/plugins/sonarsource/sonarlint-vscode/latest/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/latest/meta.yaml
@@ -12,6 +12,6 @@ category: Linter
 repository: https://www.sonarlint.org/
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java11:next
+  - image: eclipse/che-remote-plugin-runner-java8:next
   extensions:
   - https://github.com/SonarSource/sonarlint-vscode/releases/download/1.6.0/sonarlint-vscode-1.6.0.vsix

--- a/v3/plugins/sonarsource/sonarlint-vscode/latest/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/latest/meta.yaml
@@ -13,5 +13,6 @@ repository: https://www.sonarlint.org/
 spec:
   containers:
   - image: eclipse/che-remote-plugin-runner-java8:next
+    memoryLimit: "512Mi"
   extensions:
   - https://github.com/SonarSource/sonarlint-vscode/releases/download/1.6.0/sonarlint-vscode-1.6.0.vsix

--- a/v3/plugins/sonarsource/sonarlint-vscode/latest/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/latest/meta.yaml
@@ -12,6 +12,6 @@ category: Linter
 repository: https://www.sonarlint.org/
 spec:
   containers:
-  - image: garagatyi/remotetheia:java
+  - image: eclipse/che-remote-plugin-runner-java11:next
   extensions:
   - https://github.com/SonarSource/sonarlint-vscode/releases/download/1.6.0/sonarlint-vscode-1.6.0.vsix


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

### What does this PR do?
Changes container image in java based plugins to use Java11

Updated plugins:
- redhat-java
- redhat-xml
- apache-camel

### Related issue
https://github.com/eclipse/che/issues/13225