### PR TITLE
Add containers section into omnisharp and netcoredbg plugins

### DIFF
--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.1/meta.yaml
@@ -11,5 +11,8 @@ repository: https://github.com/redhat-developer/omnisharp-theia-plugin
 category: Language
 firstPublicationDate: "2019-03-13"
 spec:
+  containers:
+  - image: eclipse/che-remote-plugin-dotnet-2.2.105:next
+    memoryLimit: "1024Mi"
   extensions:
     - https://github.com/redhat-developer/omnisharp-theia-plugin/releases/download/v0.0.1/omnisharp_theia_plugin.theia

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/latest/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/latest/meta.yaml
@@ -12,5 +12,8 @@ repository: https://github.com/redhat-developer/omnisharp-theia-plugin
 category: Language
 firstPublicationDate: '2019-03-13'
 spec:
+  containers:
+  - image: eclipse/che-remote-plugin-dotnet-2.2.105:next
+    memoryLimit: "1024Mi"
   extensions:
   - https://github.com/redhat-developer/omnisharp-theia-plugin/releases/download/v0.0.1/omnisharp_theia_plugin.theia

--- a/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.1/meta.yaml
@@ -11,5 +11,8 @@ repository: https://github.com/redhat-developer/netcoredbg-theia-plugin
 category: Debugger
 firstPublicationDate: "2019-04-19"
 spec:
+  containers:
+  - image: eclipse/che-remote-plugin-dotnet-2.2.105:next
+    memoryLimit: "512Mi"
   extensions:
     - https://github.com/redhat-developer/netcoredbg-theia-plugin/releases/download/v0.0.1/netcoredbg_theia_plugin.theia

--- a/v3/plugins/redhat-developer/netcoredbg-theia-plugin/latest/meta.yaml
+++ b/v3/plugins/redhat-developer/netcoredbg-theia-plugin/latest/meta.yaml
@@ -12,5 +12,8 @@ repository: https://github.com/redhat-developer/netcoredbg-theia-plugin
 category: Debugger
 firstPublicationDate: '2019-04-19'
 spec:
+  containers:
+  - image: eclipse/che-remote-plugin-dotnet-2.2.105:next
+    memoryLimit: "512Mi"
   extensions:
   - https://github.com/redhat-developer/netcoredbg-theia-plugin/releases/download/v0.0.1/netcoredbg_theia_plugin.theia


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

### What does this PR do?
In previous versions of plugin registry if plugin is **Theia plugin** not **VSCode extension**, it should contain information about container image not in **meta.yaml**. For **v3** need to have this information in meta.yaml. So this PR provides the information about the image which should be used in  **netcoredb** and **omnisharp** plugins.