### PR TITLE
Base the GOPATH on the projects location injected by Che.

### DIFF
--- a/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
@@ -13,5 +13,8 @@ firstPublicationDate: "2019-02-21"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-go-1.10.7:next"
+      env:
+      - name: GOPATH
+        value: /go:$(CHE_PROJECTS_ROOT)
   extensions:
     - https://github.com/Microsoft/vscode-go/releases/download/0.9.2/Go-0.9.2.vsix

--- a/v3/plugins/ms-vscode/go/latest/meta.yaml
+++ b/v3/plugins/ms-vscode/go/latest/meta.yaml
@@ -9,9 +9,12 @@ description: This extension adds rich language support for the Go language
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/Microsoft/vscode-go.git
 category: Language
-firstPublicationDate: '2019-02-21'
+firstPublicationDate: "2019-02-21"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-go-1.10.7:next
+    - image: "eclipse/che-remote-plugin-go-1.10.7:next"
+      env:
+      - name: GOPATH
+        value: /go:$(CHE_PROJECTS_ROOT)
   extensions:
-  - https://github.com/Microsoft/vscode-go/releases/download/0.9.2/Go-0.9.2.vsix
+    - https://github.com/Microsoft/vscode-go/releases/download/0.9.2/Go-0.9.2.vsix


### PR DESCRIPTION
### What does this PR do?

This allows for the projects location to be dynamically discovered and be always in line with the location `mountSources` puts the volume to.

### What issue does this PR fix or reference?
https://github.com/eclipse/che/issues/13529