### PR TITLE
Set memory to 256 for YAML

### DIFF
--- a/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml
@@ -13,5 +13,6 @@ firstPublicationDate: "2019-02-20"
 spec:
   containers:
     - image: "eclipse/che-theia-endpoint-runtime:next"
+      memoryLimit: "256Mi"
   extensions:
     - https://github.com/redhat-developer/vscode-yaml/releases/download/0.3.0/redhat.vscode-yaml-0.3.0.vsix

--- a/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
@@ -13,5 +13,6 @@ firstPublicationDate: "2019-04-19"
 spec:
   containers:
     - image: "eclipse/che-theia-endpoint-runtime:next"
+      memoryLimit: "256Mi"
   extensions:
     - https://github.com/redhat-developer/vscode-yaml/releases/download/0.4.0/redhat.vscode-yaml-0.4.0.vsix

--- a/v3/plugins/redhat/vscode-yaml/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/latest/meta.yaml
@@ -15,5 +15,6 @@ firstPublicationDate: '2019-04-19'
 spec:
   containers:
   - image: eclipse/che-theia-endpoint-runtime:next
+    memoryLimit: "256Mi"
   extensions:
   - https://github.com/redhat-developer/vscode-yaml/releases/download/0.4.0/redhat.vscode-yaml-0.4.0.vsix


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

This PR sets the memory limit for vscode-yaml.

Fixes: https://github.com/eclipse/che/issues/13465
Part of: https://github.com/eclipse/che/issues/13521

Tested on both kubernetes and openshift.