### PR TITLE
Set vscode-xml memory limit to 768. Update vscode-xml to 0.7.0

### DIFF
--- a/v3/plugins/redhat/vscode-xml/0.3.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.3.0/meta.yaml
@@ -13,5 +13,6 @@ firstPublicationDate: "2019-02-20"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-runner-java11:next"
+      memoryLimit: "768Mi"
   extensions:
     - https://github.com/redhat-developer/vscode-xml/releases/download/0.3.0/redhat.vscode-xml-0.3.0.vsix

--- a/v3/plugins/redhat/vscode-xml/0.7.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.7.0/meta.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 publisher: redhat
 name: vscode-xml
-version: 0.5.1
+version: 0.7.0
 type: VS Code extension
 displayName: XML
 title: XML Language Support by Red Hat
@@ -9,10 +9,10 @@ description: This VS Code extension provides support for creating and editing XM
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-xml
 category: Language
-firstPublicationDate: "2019-04-19"
+firstPublicationDate: "2019-06-17"
 spec:
   containers:
     - image: "eclipse/che-remote-plugin-runner-java11:next"
       memoryLimit: "768Mi"
   extensions:
-    - https://github.com/redhat-developer/vscode-xml/releases/download/0.5.1/redhat.vscode-xml-0.5.1.vsix
+    - https://github.com/redhat-developer/vscode-xml/releases/download/0.7.0/vscode-xml-0.7.0-3205.vsix

--- a/v3/plugins/redhat/vscode-xml/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/latest/meta.yaml
@@ -14,5 +14,6 @@ firstPublicationDate: '2019-04-19'
 spec:
   containers:
   - image: eclipse/che-remote-plugin-runner-java11:next
+    memoryLimit: "768Mi"
   extensions:
-  - https://github.com/redhat-developer/vscode-xml/releases/download/0.5.1/redhat.vscode-xml-0.5.1.vsix
+  - https://github.com/redhat-developer/vscode-xml/releases/download/0.7.0/vscode-xml-0.7.0-3205.vsix


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

This PR sets the memory limit for vscode-xml and adds in the newest version of vscode-xml (0.7.0).

Part of: eclipse/che#13521

Tested on kubernetes.