### PR TITLE
Update redhat-java plugin to 0.46.0

### DIFF
--- a/v3/plugins/redhat/java/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.46.0/meta.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+publisher: redhat
+name: java
+version: 0.46.0
+type: VS Code extension
+displayName: Language Support for Java(TM)
+title: Language Support for Java(TM) by Red Hat
+description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/redhat-developer/vscode-java
+category: Language
+firstPublicationDate: "2019-06-18"
+spec:
+  containers:
+    - image: "eclipse/che-remote-plugin-runner-java11:next"
+      memoryLimit: "1500Mi"
+  extensions:
+    - https://github.com/microsoft/vscode-java-debug/releases/download/0.19.0/vscode-java-debug-0.19.0.vsix
+    - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.46.0-1549.vsix

--- a/v3/plugins/redhat/java/latest/meta.yaml
+++ b/v3/plugins/redhat/java/latest/meta.yaml
@@ -10,7 +10,7 @@ description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle s
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-java
 category: Language
-firstPublicationDate: '2019-05-27'
+firstPublicationDate: "2019-06-18"
 spec:
   containers:
   - image: eclipse/che-remote-plugin-runner-java11:next

--- a/v3/plugins/redhat/java/latest/meta.yaml
+++ b/v3/plugins/redhat/java/latest/meta.yaml
@@ -17,4 +17,4 @@ spec:
     memoryLimit: "1500Mi"
   extensions:
   - https://github.com/microsoft/vscode-java-debug/releases/download/0.19.0/vscode-java-debug-0.19.0.vsix
-  - http://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.45.0-1523.vsix
+  - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.46.0-1549.vsix


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

### What does this PR do?
- Adds new version of java plugin 0.46.0
- Updates latest version of java plugin to use 0.46.0