### PR TITLE
Set memory limits for old versions of plugins

### DIFF
--- a/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
@@ -14,5 +14,6 @@ spec:
   containers:
    - image: "eclipse/che-theia-endpoint-runtime:next"
      name: "vscode-typescript"
+     memoryLimit: '512Mi'
   extensions:
    - https://github.com/che-incubator/ms-code.typescript/releases/download/v1.30.2/che-typescript-language.vsix

--- a/v3/plugins/ms-python/python/2019.2.5433/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.2.5433/meta.yaml
@@ -14,5 +14,6 @@ spec:
   containers:
     - image: "eclipse/che-remote-plugin-python-3.7.3:next"
       name: "vscode-python"
+      memoryLimit: '512Mi'
   extensions:
     - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-python/vsextensions/python/2019.2.5433/vspackage

--- a/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
@@ -14,5 +14,6 @@ spec:
   containers:
     - image: "eclipse/che-remote-plugin-python-3.7.3:next"
       name: "vscode-python"
+      memoryLimit: '512Mi'
   extensions:
     - https://github.com/Microsoft/vscode-python/releases/download/2019.3.6558/ms-python-release.vsix

--- a/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
@@ -14,6 +14,7 @@ spec:
   containers:
     - image: "eclipse/che-remote-plugin-go-1.10.7:next"
       name: vscode-go
+      memoryLimit: '512Mi'
       env:
       - name: GOPATH
         value: /go:$(CHE_PROJECTS_ROOT)

--- a/v3/plugins/ms-vscode/node-debug/1.32.1/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug/1.32.1/meta.yaml
@@ -14,5 +14,6 @@ spec:
   containers:
     - image: "eclipse/che-theia-endpoint-runtime:next"
       name: vscode-node-debug-legacy
+      memoryLimit: '256Mi'
   extensions:
     - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/node-debug/1.32.1/vspackage

--- a/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
@@ -14,5 +14,6 @@ spec:
   containers:
     - image: "eclipse/che-theia-endpoint-runtime:next"
       name: vscode-node-debug
+      memoryLimit: '512Mi'
   extensions:
     - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/node-debug2/1.31.6/vspackage


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### What does this PR do?
Set memory limits for old versions of plugins

### Reference issue
https://github.com/eclipse/che/issues/13512