### PR TITLE
Separate directory for VSCode extensions

### DIFF
--- a/v3/plugins/eclipse/che-theia/7.0.0-rc-3.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0-rc-3.0/meta.yaml
@@ -51,7 +51,9 @@ spec:
      image: eclipse/che-theia:7.0.0-rc-3.0
      env:
          - name: THEIA_PLUGINS
-           value: local-dir:///plugins
+           value: local-dir:///plugins,local-dir:///vscode-plugins
+         - name: VSCODE_PLUGINS
+           value: /vscode-plugins
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
@@ -59,6 +61,10 @@ spec:
      volumes:
          - mountPath: "/plugins"
            name: plugins
+         - mountPath: "/vscode-plugins"
+           name: vscode-plugins
+         - mountPath: "/home/theia/.theia"
+           name: theia-data
      mountSources: true
      ports:
          - exposedPort: 3100

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -51,7 +51,9 @@ spec:
      image: eclipse/che-theia:next
      env:
          - name: THEIA_PLUGINS
-           value: local-dir:///plugins
+           value: local-dir:///plugins,local-dir:///vscode-plugins
+         - name: VSCODE_PLUGINS
+           value: /vscode-plugins
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
@@ -59,6 +61,10 @@ spec:
      volumes:
          - mountPath: "/plugins"
            name: plugins
+         - mountPath: "/vscode-plugins"
+           name: vscode-plugins
+         - mountPath: "/home/theia/.theia"
+           name: theia-data
      mountSources: true
      ports:
          - exposedPort: 3100


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

### What does this PR do?

For `eclipse/che-theia/7.0.0-rc-3.0` and `eclipse/che-theia/next`
- defines `VSCODE_PLUGINS` environment variable. It allow to install VS Code extensions to this directory.
- persists this directory
- adds `/vscode-plugins` to plugin sources
- persists `/home/theia/.theia` directory to be able to store Theia settings and setting of some plugins/extensions

Is needed for https://github.com/eclipse/che/issues/13834