### PR TITLE
Add java, java8 and java11 plugins 

### DIFF
--- a/v3/plugins/redhat/java/0.38.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.38.0/meta.yaml
@@ -3,7 +3,7 @@ publisher: redhat
 name: java
 version: 0.38.0
 type: VS Code extension
-displayName: Language Support for Java(TM)
+displayName: Language Support for Java 8
 title: Language and Debugger Support for Java(TM)
 description: Java Linting, debugging, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-rc-3.0"
+    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-rc-3.0"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.38.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.38.0/meta.yaml
@@ -3,7 +3,7 @@ publisher: redhat
 name: java
 version: 0.38.0
 type: VS Code extension
-displayName: Language Support for Java 8
+displayName: Language Support for Java(TM)
 title: Language and Debugger Support for Java(TM)
 description: Java Linting, debugging, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg

--- a/v3/plugins/redhat/java/0.43.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.43.0/meta.yaml
@@ -3,7 +3,7 @@ publisher: redhat
 name: java
 version: 0.43.0
 type: VS Code extension
-displayName: Language Support for Java 8
+displayName: Language Support for Java(TM)
 title: Language and Debugger Support for Java(TM)
 description: Java Linting, debugging, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg

--- a/v3/plugins/redhat/java/0.43.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.43.0/meta.yaml
@@ -3,7 +3,7 @@ publisher: redhat
 name: java
 version: 0.43.0
 type: VS Code extension
-displayName: Language Support for Java(TM)
+displayName: Language Support for Java 8
 title: Language and Debugger Support for Java(TM)
 description: Java Linting, debugging, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-25"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-rc-3.0"
+    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-rc-3.0"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.45.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.45.0/meta.yaml
@@ -3,7 +3,7 @@ publisher: redhat
 name: java
 version: 0.45.0
 type: VS Code extension
-displayName: Language Support for Java 8
+displayName: Language Support for Java(TM)
 title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg

--- a/v3/plugins/redhat/java/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.46.0/meta.yaml
@@ -3,7 +3,7 @@ publisher: redhat
 name: java
 version: 0.46.0
 type: VS Code extension
-displayName: Language Support for Java(TM)
+displayName: Language Support for Java 8
 title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-rc-3.0"
+    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-rc-3.0"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java11/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java11/0.46.0/meta.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 publisher: redhat
-name: java
-version: 0.45.0
+name: java11
+version: 0.46.0
 type: VS Code extension
-displayName: Language Support for Java 8
+displayName: Language Support for Java 11
 title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-java
 category: Language
-firstPublicationDate: "2019-05-27"
+firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-rc-3.0"
+    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-rc-3.0"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:
-    - https://github.com/microsoft/vscode-java-debug/releases/download/0.16.0/vscode-java-debug-0.16.0.vsix
-    - http://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.45.0-1523.vsix
+    - https://github.com/microsoft/vscode-java-debug/releases/download/0.19.0/vscode-java-debug-0.19.0.vsix
+    - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.46.0-1549.vsix

--- a/v3/plugins/redhat/java11/latest/meta.yaml
+++ b/v3/plugins/redhat/java11/latest/meta.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 publisher: redhat
-name: java
+name: java11
 version: latest
 type: VS Code extension
-displayName: Language Support for Java 8
+displayName: Language Support for Java 11
 title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support
   and more...
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java8:7.0.0-rc-3.0
+  - image: eclipse/che-remote-plugin-runner-java11:7.0.0-rc-3.0
     name: vscode-java
     memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java8/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.46.0/meta.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 publisher: redhat
-name: java11
+name: java8
 version: 0.46.0
 type: VS Code extension
 displayName: Language Support for Java 8

--- a/v3/plugins/redhat/java8/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.46.0/meta.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 publisher: redhat
-name: java
+name: java11
 version: 0.46.0
 type: VS Code extension
-displayName: Language Support for Java(TM)
+displayName: Language Support for Java 8
 title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg

--- a/v3/plugins/redhat/java8/latest/meta.yaml
+++ b/v3/plugins/redhat/java8/latest/meta.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 publisher: redhat
-name: java11
+name: java8
 version: latest
 type: VS Code extension
 displayName: Language Support for Java 8

--- a/v3/plugins/redhat/java8/latest/meta.yaml
+++ b/v3/plugins/redhat/java8/latest/meta.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 publisher: redhat
-name: java
+name: java11
 version: latest
 type: VS Code extension
-displayName: Language Support for Java(TM)
+displayName: Language Support for Java 8
 title: Language Support for Java(TM) by Red Hat
 description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support
   and more...


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

### What does this PR do?
This PR creates next structure of Java plug-ins:
* **java**
  * 0.38.0
  * 0.43.0
  * 0.45.0
  * 0.46.0
  * latest
* **java8**
   * 0.46.0
   *  latest
* **java11**
   * 0.46.0
   *  latest

The plug-ins from **java** folder (default) use container image with Java 8. That means that all existing devfiles will use Java8 instead of Java11 in jdt.ls base image.

#### Display name of the plugins: 
from **java** is **Language Support for Java(TM)**
from **java8** is **Language Support for Java 8**
from **java11** is **Language Support for Java 11**

### Related issue
https://github.com/eclipse/che/issues/13547