### PR TITLE
CI updates: eclipse org and nightly builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 ## Build Eclipse Che plugin registry container image
 
-Most of the time you won't need to rebuild the image because we build ```quay.io/openshiftio/che-plugin-registry:latest``` after every commit in master. In case you needed to change the content of the registry (e.g. add or modify some plugins meta.yaml) you can build your own image executing
+Most of the time you won't need to rebuild the image because we build ```quay.io/eclipse/che-plugin-registry:nightly``` after every commit in master. In case you needed to change the content of the registry (e.g. add or modify some plugins meta.yaml) you can build your own image executing
 
 ```shell
-docker build --no-cache -t quay.io/openshiftio/che-plugin-registry .
+docker build --no-cache -t quay.io/eclipse/che-plugin-registry:nightly .
 ```
 
 Where `--no-cache` is needed to prevent usage of cached layers with plugin registry files.
@@ -22,8 +22,8 @@ You can deploy Che plugin registry on Openshift with command.
 
 ```bash
   oc new-app -f openshift/che-plugin-registry.yml \
-             -p IMAGE="quay.io/openshiftio/che-plugin-registry" \
-             -p IMAGE_TAG="latest" \
+             -p IMAGE="quay.io/eclipse/che-plugin-registry" \
+             -p IMAGE_TAG="nightly" \
              -p PULL_POLICY="IfNotPresent"
 ```
 
@@ -54,7 +54,7 @@ helm delete --purge che-plugin-registry
 ## Run Eclipse Che plugin registry using Docker
 
 ```bash
-docker run -it  --rm  -p 8080:8080 quay.io/openshiftio/che-plugin-registry
+docker run -it  --rm  -p 8080:8080 quay.io/eclipse/che-plugin-registry:nightly
 ```
 
 ## Plugin meta YAML structure

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,4 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-docker build -t eclipse/che-plugin-registry:latest .
+docker build -t quay.io/eclipse/che-plugin-registry:nightly .

--- a/kubernetes/che-plugin-registry/values.yaml
+++ b/kubernetes/che-plugin-registry/values.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-chePluginRegistryImage: eclipse/che-plugin-registry
+chePluginRegistryImage: quay.io/eclipse/che-plugin-registry:nightly
 chePluginRegistryImagePullPolicy: Always
 chePluginRegistryMemoryLimit: 256Mi
 #chePluginRegistryIngressSecretName: che-tls

--- a/openshift/che-plugin-registry.yml
+++ b/openshift/che-plugin-registry.yml
@@ -83,13 +83,13 @@ objects:
       name: che-plugin-registry
 parameters:
 - name: IMAGE
-  value: eclipse/che-plugin-registry
+  value: quay.io/eclipse/che-plugin-registry
   displayName: Eclipse Che plugin registry image
   description: Che plugin registry Docker image. Defaults to eclipse/che-plugin-registry
 - name: IMAGE_TAG
-  value: latest
+  value: nightly
   displayName: Eclipse Che plugin registry version
-  description: Eclipse Che plugin registry version which defaults to latest
+  description: Eclipse Che plugin registry version which defaults to nightly
 - name: MEMORY_LIMIT
   value: 256Mi
   displayName: Memory Limit


### PR DESCRIPTION
These are che-plugin-registry modifications to:

- publish nightly builds ([openshiftio-cico-jobs PR](https://github.com/openshiftio/openshiftio-cico-jobs/pull/1043))
- push images to quay.io/eclipse 


That correspond to what has been done che-devfile-registry side with https://github.com/eclipse/che-devfile-registry/pull/33 and https://github.com/eclipse/che-devfile-registry/pull/35

Related to issue https://github.com/eclipse/che/issues/13915 and to the "Update release process to include new repositories" enhancement of [Che 7 endgame](https://github.com/eclipse/che/issues/13637) 
