### PR TITLE
update helm chart probes to current URL

### DIFF
--- a/kubernetes/che-plugin-registry/templates/deployment.yaml
+++ b/kubernetes/che-plugin-registry/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - containerPort: 8080
         livenessProbe:
           httpGet:
-            path: /plugins/
+            path: /v3/plugins/
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30
@@ -45,7 +45,7 @@ spec:
           timeoutSeconds: 3
         readinessProbe:
           httpGet:
-            path: /plugins/
+            path: /v3/plugins/
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 3


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

### What does this PR do?
`/plugins/` is deprecated now. Use `/v3/plugins/` instead