### PR TITLE
Change next version of `che-theia` to `next`

### DIFF
--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -48,7 +48,7 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: eclipse/che-theia:7.0.0-next
+     image: eclipse/che-theia:next
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins


### PR DESCRIPTION
### What does this PR do?

Change next version of `che-theia` to `next` 
This one should always be `next` and never updated I suppose