### PR TITLE
[airgap] explicitly reference docker.io registry

### DIFF
--- a/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
+++ b/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2018-04-23"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:7.0.0-next"
       name: vscode-apache-camel
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/camel-tooling/vscode-apache-camel/latest/meta.yaml
+++ b/v3/plugins/camel-tooling/vscode-apache-camel/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2018-04-23'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java11:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-runner-java11:7.0.0-next"
     name: vscode-apache-camel
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
+++ b/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-08-06'
 spec:
   containers:
-    - image: 'eclipse/che-remote-plugin-clang-8:7.0.0-next'
+    - image: "docker.io/eclipse/che-remote-plugin-clang-8:7.0.0-next"
       name: cpp-plugins
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/cpptools/latest/meta.yaml
+++ b/v3/plugins/che-incubator/cpptools/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-08-06'
 spec:
   containers:
-    - image: 'eclipse/che-remote-plugin-clang-8:7.0.0-next'
+    - image: "docker.io/eclipse/che-remote-plugin-clang-8:7.0.0-next"
       name: cpp-plugins
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/theia-dev/0.0.1/meta.yaml
+++ b/v3/plugins/che-incubator/theia-dev/0.0.1/meta.yaml
@@ -19,7 +19,7 @@ spec:
       protocol: http
   containers:
    - name: theia-dev
-     image: eclipse/che-theia-dev:nightly
+     image: "docker.io/eclipse/che-theia-dev:nightly"
      commands:
        - name: uname
          workingDir: "$(project)"

--- a/v3/plugins/che-incubator/theia-dev/latest/meta.yaml
+++ b/v3/plugins/che-incubator/theia-dev/latest/meta.yaml
@@ -19,7 +19,7 @@ spec:
     protocol: http
   containers:
   - name: theia-dev
-    image: eclipse/che-theia-dev:nightly
+    image: "docker.io/eclipse/che-theia-dev:nightly"
     commands:
     - name: uname
       workingDir: $(project)

--- a/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-   - image: "eclipse/che-theia-endpoint-runtime:7.0.0-next"
+   - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
      name: "vscode-typescript"
      memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: eclipse/che-theia-endpoint-runtime:7.0.0-next
+  - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
     name: vscode-typescript
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/typescript/latest/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: eclipse/che-theia-endpoint-runtime:7.0.0-next
+  - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
     name: vscode-typescript
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/dirigiblelabs/dirigible/3.4.0/meta.yaml
+++ b/v3/plugins/dirigiblelabs/dirigible/3.4.0/meta.yaml
@@ -20,7 +20,7 @@ spec:
         type: ide
   containers:
    - name: eclipse-dirigible
-     image: dirigiblelabs/dirigible-openshift:3.4.0
+     image: "docker.io/dirigiblelabs/dirigible-openshift:3.4.0"
      env:
          - name: DIRIGIBLE_DATABASE_PROVIDER
            value: "local"

--- a/v3/plugins/dirigiblelabs/dirigible/latest/meta.yaml
+++ b/v3/plugins/dirigiblelabs/dirigible/latest/meta.yaml
@@ -20,7 +20,7 @@ spec:
       type: ide
   containers:
   - name: eclipse-dirigible
-    image: dirigiblelabs/dirigible-openshift:3.4.0
+    image: "docker.io/dirigiblelabs/dirigible-openshift:3.4.0"
     env:
     - name: DIRIGIBLE_DATABASE_PROVIDER
       value: local

--- a/v3/plugins/eclipse/che-machine-exec-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/0.0.1/meta.yaml
@@ -22,6 +22,6 @@ spec:
         discoverable: false
   containers:
    - name: che-machine-exec
-     image: eclipse/che-machine-exec
+     image: "docker.io/eclipse/che-machine-exec"
      ports:
        - exposedPort: 4444

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.0.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.0.0/meta.yaml
@@ -24,6 +24,6 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: che-machine-exec
-     image: eclipse/che-machine-exec:7.0.0
+     image: "docker.io/eclipse/che-machine-exec:7.0.0"
      ports:
        - exposedPort: 4444

--- a/v3/plugins/eclipse/che-machine-exec-plugin/latest/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/latest/meta.yaml
@@ -22,6 +22,6 @@ spec:
       discoverable: false
   containers:
   - name: che-machine-exec
-    image: eclipse/che-machine-exec
+    image: "docker.io/eclipse/che-machine-exec"
     ports:
     - exposedPort: 4444

--- a/v3/plugins/eclipse/che-machine-exec-plugin/next/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/next/meta.yaml
@@ -24,6 +24,6 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: che-machine-exec
-     image: eclipse/che-machine-exec:7.0.0-next
+     image: "docker.io/eclipse/che-machine-exec:7.0.0-next"
      ports:
        - exposedPort: 4444

--- a/v3/plugins/eclipse/che-theia/7.0.0-next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0-next/meta.yaml
@@ -48,7 +48,7 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: eclipse/che-theia:7.0.0-next
+     image: "docker.io/eclipse/che-theia:7.0.0-next"
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins

--- a/v3/plugins/eclipse/che-theia/7.0.0-rc-3.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0-rc-3.0/meta.yaml
@@ -48,7 +48,7 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: eclipse/che-theia:7.0.0-rc-3.0
+     image: "docker.io/eclipse/che-theia:7.0.0-rc-3.0"
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins

--- a/v3/plugins/eclipse/che-theia/7.0.0-rc-4.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0-rc-4.0/meta.yaml
@@ -48,7 +48,7 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: eclipse/che-theia:7.0.0-rc-4.0
+     image: "docker.io/eclipse/che-theia:7.0.0-rc-4.0"
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins

--- a/v3/plugins/eclipse/che-theia/7.0.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0/meta.yaml
@@ -48,7 +48,7 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: eclipse/che-theia:7.0.0
+     image: "docker.io/eclipse/che-theia:7.0.0"
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins

--- a/v3/plugins/eclipse/che-theia/latest/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/latest/meta.yaml
@@ -48,7 +48,7 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: eclipse/che-theia:7.0.0
+     image: "docker.io/eclipse/che-theia:7.0.0"
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -48,7 +48,7 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: eclipse/che-theia:next
+     image: "docker.io/eclipse/che-theia:next"
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-03-11"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-kubernetes-tooling-0.1.17:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-0.1.17:7.0.0-next"
       name: "vscode-kubernetes-tools"
   extensions:
     - https://github.com/Azure/vscode-kubernetes-tools/releases/download/0.1.17/vscode-kubernetes-tools-0.1.17.vsix

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-05-15"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:7.0.0-next"
       name: "vscode-kubernetes-tools"
       memoryLimit: "1G"
   extensions:

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/latest/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: '2019-05-15'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:7.0.0-next"
     name: vscode-kubernetes-tools
   extensions:
   - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.0/vscode-kubernetes-tools-1.0.0.vsix

--- a/v3/plugins/ms-python/python/2019.2.5433/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.2.5433/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-03-05"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-python-3.7.3:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-python-3.7.3:7.0.0-next"
       name: "vscode-python"
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-23"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-python-3.7.3:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-python-3.7.3:7.0.0-next"
       name: "vscode-python"
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-python-3.7.3:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-python-3.7.3:7.0.0-next"
     name: vscode-python
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-python/python/latest/meta.yaml
+++ b/v3/plugins/ms-python/python/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-python-3.7.3:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-python-3.7.3:7.0.0-next"
     name: vscode-python
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-vscode/go/0.11.0/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.11.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-go-1.10.7:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-go-1.10.7:7.0.0-next"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-21"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-go-1.10.7:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-go-1.10.7:7.0.0-next"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/go/latest/meta.yaml
+++ b/v3/plugins/ms-vscode/go/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-go-1.10.7:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-go-1.10.7:7.0.0-next"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/node-debug/1.32.1/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug/1.32.1/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-    - image: "eclipse/che-theia-endpoint-runtime:7.0.0-next"
+    - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
       name: vscode-node-debug-legacy
       memoryLimit: '256Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug/1.35.2/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug/1.35.2/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: eclipse/che-theia-endpoint-runtime:7.0.0-next
+  - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
     name: vscode-node-debug-legacy
     memoryLimit: '256Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug/latest/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: eclipse/che-theia-endpoint-runtime:7.0.0-next
+  - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
     name: vscode-node-debug-legacy
     memoryLimit: '256Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-    - image: "eclipse/che-theia-endpoint-runtime:7.0.0-next"
+    - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
       name: vscode-node-debug
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: eclipse/che-theia-endpoint-runtime:7.0.0-next
+  - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
     name: vscode-node-debug
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug2/latest/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: eclipse/che-theia-endpoint-runtime:7.0.0-next
+  - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
     name: vscode-node-debug
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-03-13"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.2/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-19"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/latest/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: "2019-06-19"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next"
     name: theia-netcoredbg
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat-developer/netcoredbg-theia-plugin/latest/meta.yaml
+++ b/v3/plugins/redhat-developer/netcoredbg-theia-plugin/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-04-19'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next"
     name: theia-netcoredbg
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.38.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.38.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.43.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.43.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-25"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.45.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.45.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-05-27"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.46.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/latest/meta.yaml
+++ b/v3/plugins/redhat/java/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java8:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
     name: vscode-java
     memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java11/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java11/0.46.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:7.0.0-next"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java11/latest/meta.yaml
+++ b/v3/plugins/redhat/java11/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java11:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-runner-java11:7.0.0-next"
     name: vscode-java
     memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java8/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.46.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java8/latest/meta.yaml
+++ b/v3/plugins/redhat/java8/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java8:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
     name: vscode-java
     memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
+++ b/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-php7:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-php7:7.0.0-next"
       name: php-debugger
   extensions:
     - https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix

--- a/v3/plugins/redhat/php-debugger/latest/meta.yaml
+++ b/v3/plugins/redhat/php-debugger/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-php7:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-php7:7.0.0-next"
       name: php-debugger
   extensions:
     - https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix

--- a/v3/plugins/redhat/php/1.0.13/meta.yaml
+++ b/v3/plugins/redhat/php/1.0.13/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-php7:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-php7:7.0.0-next"
       name: php-intelephense
       memoryLimit: "1000Mi"
   extensions:

--- a/v3/plugins/redhat/php/latest/meta.yaml
+++ b/v3/plugins/redhat/php/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-php7:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-php7:7.0.0-next"
       name: php-intelephense
       memoryLimit: "1000Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.17/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.17/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-03-11"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-openshift-connector-0.0.17:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.0.17:7.0.0-next"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.19/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.19/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-openshift-connector-0.0.17:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.0.17:7.0.0-next"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.21/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.21/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-05-22"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-openshift-connector-0.0.21:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.0.21:7.0.0-next"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Other
 firstPublicationDate: '2019-04-19'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-openshift-connector-0.0.21:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.0.21:7.0.0-next"
     name: "vscode-openshift-connector"
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-xml/0.3.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.3.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:7.0.0-next"
       name: vscode-xml
       memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-xml/0.5.1/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.5.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:7.0.0-next"
       name: vscode-xml
       memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-xml/0.7.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.7.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-17"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java11:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:7.0.0-next"
       memoryLimit: "768Mi"
   extensions:
     - https://github.com/redhat-developer/vscode-xml/releases/download/0.7.0/vscode-xml-0.7.0-3205.vsix

--- a/v3/plugins/redhat/vscode-xml/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/latest/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: '2019-04-19'
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java11:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-runner-java11:7.0.0-next"
     name: vscode-xml
     memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "eclipse/che-theia-endpoint-runtime:7.0.0-next"
+    - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
       name: vscode-yaml
       memoryLimit: "256Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "eclipse/che-theia-endpoint-runtime:7.0.0-next"
+    - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
       name: vscode-yaml
       memoryLimit: "256Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-yaml/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/latest/meta.yaml
@@ -14,7 +14,7 @@ category: Language
 firstPublicationDate: '2019-04-19'
 spec:
   containers:
-  - image: eclipse/che-theia-endpoint-runtime:7.0.0-next
+  - image: "docker.io/eclipse/che-theia-endpoint-runtime:7.0.0-next"
     name: vscode-yaml
     memoryLimit: "256Mi"
   extensions:

--- a/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Linter
 repository: https://www.sonarlint.org/
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:7.0.0-next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
       name: vscode-sonarlint
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/sonarsource/sonarlint-vscode/latest/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Linter
 repository: https://www.sonarlint.org/
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-runner-java8:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-runner-java8:7.0.0-next"
     name: vscode-sonarlint
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/ws-skeleton/eclipseide/4.9.0/meta.yaml
+++ b/v3/plugins/ws-skeleton/eclipseide/4.9.0/meta.yaml
@@ -20,7 +20,7 @@ spec:
         type: ide
   containers:
    - name: eclipse-ide
-     image: wsskeleton/eclipse-broadway
+     image: "docker.io/wsskeleton/eclipse-broadway"
      mountSources: true
      ports:
          - exposedPort: 5000

--- a/v3/plugins/ws-skeleton/eclipseide/latest/meta.yaml
+++ b/v3/plugins/ws-skeleton/eclipseide/latest/meta.yaml
@@ -20,7 +20,7 @@ spec:
       type: ide
   containers:
   - name: eclipse-ide
-    image: wsskeleton/eclipse-broadway
+    image: "docker.io/wsskeleton/eclipse-broadway"
     mountSources: true
     ports:
     - exposedPort: 5000

--- a/v3/plugins/ws-skeleton/jupyter/5.7.0/meta.yaml
+++ b/v3/plugins/ws-skeleton/jupyter/5.7.0/meta.yaml
@@ -20,7 +20,7 @@ spec:
         type: ide
   containers:
    - name: jupyter-notebook
-     image: ksmster/che-editor-jupyter:5.7.0
+     image: "docker.io/ksmster/che-editor-jupyter:5.7.0"
      env:
          - name: JUPYTER_NOTEBOOK_DIR
            value: /projects

--- a/v3/plugins/ws-skeleton/jupyter/latest/meta.yaml
+++ b/v3/plugins/ws-skeleton/jupyter/latest/meta.yaml
@@ -20,7 +20,7 @@ spec:
       type: ide
   containers:
   - name: jupyter-notebook
-    image: ksmster/che-editor-jupyter:5.7.0
+    image: "docker.io/ksmster/che-editor-jupyter:5.7.0"
     env:
     - name: JUPYTER_NOTEBOOK_DIR
       value: /projects


### PR DESCRIPTION
explicitly reference docker.io registry since that's where all the images live; also let's be consistent with double quotes, single quotes, and no quotes: switch to quotes everywhere

Change-Id: If528213681ab79ac60b4fd97839b8f275bc56de9
Signed-off-by: nickboldt <nboldt@redhat.com>