### PR TITLE
Use plugin patcher to inject remote plugin runtime.

### DIFF
--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -46,6 +46,19 @@ spec:
       attributes:
         protocol: http
         discoverable: false
+  pluginPatcher:
+    pluginTypeMatcher: ["vs code extension", "theia plugin"]
+    pluginContainerCommand: ["sh", "-c"]
+    pluginContainerArgs: ["/plugins/remote-launcher/entrypoint.sh"]
+    initContainers:
+      - name: theia-remote-plugin-laucher
+        image: aandrienko/che-theia-endpoint-runtime:next
+        initContainer: true
+        command: ['cp']
+        args: ['-rf', '/remote-plugin-launcher', '/plugins/remote-launcher']
+        volumes:
+          - mountPath: "/plugins"
+            name: plugins
   containers:
    - name: theia-ide
      image: "docker.io/eclipse/che-theia:next"

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -51,8 +51,8 @@ spec:
     pluginContainerCommand: ["sh", "-c"]
     pluginContainerArgs: ["/plugins/remote-launcher/entrypoint.sh"]
     initContainers:
-      - name: theia-remote-plugin-laucher
-        image: aandrienko/che-theia-endpoint-runtime:next
+      - name: theia-remote-plugin-launcher
+        image: eclipse/che-theia-endpoint-runtime:next
         initContainer: true
         command: ['cp']
         args: ['-rf', '/remote-plugin-launcher', '/plugins/remote-launcher']


### PR DESCRIPTION
### What does this PR do?
Use plugin patcher to inject remote plugin runtime.

### Referenced issue:
https://github.com/eclipse/che/issues/13387

### Depends on:
https://github.com/eclipse/che-plugin-broker/pull/71
https://github.com/eclipse/che-theia/pull/410
https://github.com/eclipse/che/pull/14333

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>