### PR TITLE
Add option to cache .vsix and .theia artifacts during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM alpine:3.10 AS builder
-RUN apk add --no-cache py-pip jq bash && pip install yq jsonschema
 
-COPY .htaccess README.md ./scripts/*.sh ./scripts/meta.yaml.schema /build/
+# Builder: check meta.yamls and create index.json
+FROM alpine:3.10 AS builder
+RUN apk add --no-cache py-pip jq bash wget && pip install yq jsonschema
+
+COPY ./scripts/*.sh ./scripts/meta.yaml.schema /build/
 COPY /v3 /build/v3
 WORKDIR /build/
 RUN ./check_plugins_location.sh v3
@@ -17,9 +19,19 @@ RUN ./set_plugin_dates.sh v3
 RUN ./check_plugins_viewer_mandatory_fields.sh v3
 RUN ./ensure_latest_exists.sh
 RUN ./index.sh v3 > /build/v3/plugins/index.json
+RUN chmod -R g+rwX /build
 
-FROM registry.centos.org/centos/httpd-24-centos7
-RUN mkdir /var/www/html/plugins
-COPY --from=builder /build/ /var/www/html/
-USER 0
-RUN chmod -R g+rwX /var/www/html/v3/plugins
+# Build registry, copying meta.yamls and index.json from builder
+FROM registry.centos.org/centos/httpd-24-centos7 AS registry
+COPY README.md .htaccess /var/www/html/
+COPY --from=builder /build/v3 /var/www/html/v3
+
+# Offline build: cache .theia and .vsix files in registry itself and update metas
+FROM builder AS offline-builder
+RUN ./cache_artifacts.sh v3
+RUN chmod -R g+rwX /build
+
+# Offline registry: copy updated meta.yamls and cached extensions
+FROM registry AS offline-registry
+COPY --from=offline-builder /build/v3 /var/www/html/v3
+WORKDIR /var/www/html

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -6,10 +6,12 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM alpine:3.10 AS builder
-RUN apk add --no-cache py-pip jq bash && pip install yq jsonschema
 
-COPY .htaccess README.md ./scripts/*.sh ./scripts/meta.yaml.schema /build/
+# Builder: check meta.yamls and create index.json
+FROM alpine:3.10 AS builder
+RUN apk add --no-cache py-pip jq bash wget && pip install yq jsonschema
+
+COPY ./scripts/*.sh ./scripts/meta.yaml.schema /build/
 COPY /v3 /build/v3
 WORKDIR /build/
 RUN ./check_plugins_location.sh v3
@@ -17,8 +19,10 @@ RUN ./set_plugin_dates.sh v3
 RUN ./check_plugins_viewer_mandatory_fields.sh v3
 RUN ./ensure_latest_exists.sh
 RUN ./index.sh v3 > /build/v3/plugins/index.json
+RUN chmod -R g+rwX /build
 
-FROM quay.io/openshiftio/rhel-base-httpd:latest
+# Build registry, copying meta.yamls and index.json from builder
+FROM quay.io/openshiftio/rhel-base-httpd:latest AS registry
 
 RUN sed -i -e "s,Listen 80,Listen 8080," /etc/httpd/conf/httpd.conf
 RUN sed -i -e "s,logs/error_log,/dev/stderr," /etc/httpd/conf/httpd.conf
@@ -31,9 +35,20 @@ EXPOSE 80
 RUN chmod a+rwX            /etc/httpd/conf
 RUN chmod a+rwX            /run/httpd
 
-RUN mkdir /var/www/html/v3
-COPY --from=builder /build/ /var/www/html/
+COPY README.md .htaccess /var/www/html/
+COPY --from=builder /build/v3 /var/www/html/v3
 
 STOPSIGNAL SIGWINCH
 
 ENTRYPOINT ["/usr/sbin/httpd", "-D", "FOREGROUND"]
+
+# Offline build: cache .theia and .vsix files in registry itself and update metas
+FROM builder AS offline-builder
+RUN ./cache_artifacts.sh v3
+RUN chmod -R g+rwX /build
+
+# Offline registry: copy updated meta.yamls and cached extensions
+FROM registry AS offline-registry
+COPY --from=offline-builder /build/v3 /var/www/html/v3
+USER 0
+WORKDIR /var/www/html

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Useful when you change plugin metadata files and rebuild the image.
 
 Note that the Dockerfiles feature multi-stage build, so it requires Docker version 17.05 or higher.
 
+### Offline and airgapped registry images
+
+It's possible to build an image for the plugin registry that includes all referenced extension artifacts (i.e. all `.theia` and `.vsix` archives). This is done using the `Dockerfile.caching` dockerfile during the build, which downloads artifacts and rewrites the devfiles to extensions cached in `v3/resources/`.
+
+```shell
+docker build --no-cache -t quay.io/eclipse/che-plugin-registry:offline -f ./Dockerfile.caching .
+```
+
+Note that support for relative extensions was added in `v0.20` of the plugin broker.
+
 ## Run Eclipse Che plugin registry on OpenShift
 
 You can deploy Che plugin registry on Openshift with command.
@@ -120,6 +130,7 @@ spec:                  # spec (used to be che-plugin.yaml)
     - https://github.com/Azure/vscode-kubernetes-tools/releases/download/0.1.17/vscode-kubernetes-tools-0.1.17.vsix # example
     - vscode:extension/redhat.vscode-xml # example
     - https://github.com/redhat-developer/omnisharp-theia-plugin/releases/download/v0.0.1/omnisharp_theia_plugin.theia # example
+    - relative:extension/resources/java-0.46.0-1549.vsix # example; see [4]
 ```
 
 1 - Category must be equal to one of the following: "Editor", "Debugger", "Formatter", "Language", "Linter", "Snippet", "Theme", "Other"
@@ -127,6 +138,8 @@ spec:                  # spec (used to be che-plugin.yaml)
 2 - firstPublicationDate is not required to be present in YAML, as if not present, it will be generated during Plugin Registry dockerimage build
 
 3 - latestUpdateDate is not required to be present in YAML, as it will be generated during Plugin Registry dockerimage build
+
+4 - extensions starting with `relative:extension` are resolved relative to the path of `index.json` -- e.g. `v3`. This is primarily to support an offline or airgapped instance of the plugin registry. See [Offline and airgapped registry images](#offline-and-airgapped-registry-images) for details.
 
 Note that the `spec` section above comes from the older `che-plugin.yaml` spec. The `endpoints`, `containers`, and `workspaceEnv` are passed back to Che server and are used to define the sidecar that is added to the workspace.
 
@@ -271,7 +284,7 @@ The following [CentOS CI jobs](https://ci.centos.org/) are associated with the r
 
 - [`master`](https://ci.centos.org/job/devtools-che-plugin-registry-build-master/) - builds CentOS images on each commit to the [`master`](https://github.com/eclipse/che-plugin-registry/tree/master) branch and pushes them to [quay.io](https://quay.io/organization/eclipse).
 - [`nightly`](https://ci.centos.org/job/devtools-che-plugin-registry-nightly/) - builds CentOS images and pushes them to [quay.io](https://quay.io/organization/eclipse) on a daily basis from the [`master`](https://github.com/eclipse/che-plugin-registry/tree/master) branch. The `nightly` version of the plugin registry is used by default by the `nightly` version of the [Eclipse Che](https://github.com/eclipse/che), which is also built on a daily basis by the [`all-che-docker-images-nightly`](all-che-docker-images-nightly/) CI job.
-- [`release`](https://ci.centos.org/job/devtools-che-plugin-registry-release/) - builds CentOS and corresponding RHEL images from the [`release`](https://github.com/eclipse/che-plugin-registry/tree/release) branch. CentOS images are public and pushed to [quay.io](https://quay.io/organization/eclipse). RHEL images are also pushed to quay.io, but to the private repositories and then used by the ["Hosted Che"](https://www.eclipse.org/che/docs/che-7/hosted-che/) plugin registry - https://che-plugin-registry.openshift.io/. 
+- [`release`](https://ci.centos.org/job/devtools-che-plugin-registry-release/) - builds CentOS and corresponding RHEL images from the [`release`](https://github.com/eclipse/che-plugin-registry/tree/release) branch. CentOS images are public and pushed to [quay.io](https://quay.io/organization/eclipse). RHEL images are also pushed to quay.io, but to the private repositories and then used by the ["Hosted Che"](https://www.eclipse.org/che/docs/che-7/hosted-che/) plugin registry - https://che-plugin-registry.openshift.io/.
 - [`release-preview`](https://ci.centos.org/job/devtools-che-plugin-registry-release-preview/) - builds CentOS and corresponding RHEL images from the [`release-preview`](https://github.com/eclipse/che-plugin-registry/tree/release-preview) branch and automatically updates ["Hosted Che"](https://www.eclipse.org/che/docs/che-7/hosted-che/) staging plugin registry deployment based on the new version of images - https://che-plugin-registry.prod-preview.openshift.io/. CentOS images are public and pushed to [quay.io](https://quay.io/organization/eclipse). RHEL images are also pushed to quay.io, but to the private repositories.
 
 ### License

--- a/build.sh
+++ b/build.sh
@@ -8,4 +8,4 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-docker build -t quay.io/eclipse/che-plugin-registry:nightly .
+docker build -t quay.io/eclipse/che-plugin-registry:nightly --target registry .

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -99,7 +99,7 @@ function build_and_push() {
 
   # Let's build and push image to 'quay.io' using git commit hash as tag first
   set_git_commit_tag
-  docker build -t ${IMAGE} -f ${DOCKERFILE} .
+  docker build -t ${IMAGE} -f ${DOCKERFILE} --target registry .
   tag_push "${REGISTRY}/${ORGANIZATION}/${IMAGE}:${GIT_COMMIT_TAG}"
   echo "CICO: '${GIT_COMMIT_TAG}' version of images pushed to '${REGISTRY}/${ORGANIZATION}' organization"
 

--- a/scripts/cache_artifacts.sh
+++ b/scripts/cache_artifacts.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Download referenced extension artifacts to <plugin root>/resources
+# Arguments:
+# 1 - plugin root folder, e.g. 'v3'
+
+set -e
+
+readarray -d '' metas < <(find "$1" -name 'meta.yaml' -print0)
+
+RESOURCES_DIR="${1}/resources/"
+TEMP_DIR="${1}/extensions_temp/"
+
+mkdir -p "${RESOURCES_DIR}" "${TEMP_DIR}"
+for extension in $(yq -r '.spec.extensions[]?' "${metas[@]}" | sort | uniq); do
+  echo -en "Caching extension ${extension}\n    "
+  # Workaround for getting filenames through content-disposition: copy to temp
+  # dir and read filename before moving to /resources.
+  wget -P "${TEMP_DIR}" -nv --content-disposition "${extension}"
+  file=$(find "${TEMP_DIR}" -type f)
+  filename=$(basename "${file}")
+
+  # Strip protocol and filename from URL
+  target_dir=${extension#*//}
+  target_dir=${target_dir%/*}
+  mkdir -p "${RESOURCES_DIR%/}/${target_dir}"
+
+  destination="${target_dir%/}/${filename}"
+  if [ -f "${RESOURCES_DIR%/}/${destination}" ]; then
+    echo "    Encoutered duplicate file: ${RESOURCES_DIR%/}/${destination}"
+    echo "    while processing ${extension}"
+    exit 1
+  fi
+
+  # echo "    Caching ${filename} to ${RESOURCES_DIR%/}/${destination}"
+  mv "${file}" "${RESOURCES_DIR%/}/${destination}"
+
+  echo "    Rewriting meta.yaml '${extension}' -> 'relative:extension/resources/${destination#/}''"
+  sed -i "s|${extension}|relative:extension/resources/${destination#/}|" "${metas[@]}"
+done
+
+rm -rf "${TEMP_DIR}"


### PR DESCRIPTION
### What does this PR do?
Add `cache_artifacts.sh` and some optional build stages in the Dockerfile / Dockerfile.rhel which can be used to build a plugin registry that includes .vsix and .theia files, to support running Che in an air-gapped scenario.

PR is ready to merge.