### PR TITLE
Update badges to refer to their respective CI jobs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![CircleCI](https://circleci.com/gh/eclipse/che-plugin-registry.svg?style=svg)](https://circleci.com/gh/eclipse/che-plugin-registry)
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-plugin-registry-build-master/)](https://ci.centos.org/job/devtools-che-plugin-registry-build-master/)
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-plugin-registry-nightly/)](https://ci.centos.org/job/devtools-che-plugin-registry-nightly/)
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-plugin-registry-release/)](https://ci.centos.org/job/devtools-che-plugin-registry-release/)
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-plugin-registry-release-preview/)](https://ci.centos.org/job/devtools-che-plugin-registry-release-preview/)
+[![Master Build Status](https://ci.centos.org/buildStatus/icon?subject=master&job=devtools-che-plugin-registry-build-master/)](https://ci.centos.org/job/devtools-che-plugin-registry-build-master/)
+[![Nightly Build Status](https://ci.centos.org/buildStatus/icon?subject=nightly&job=devtools-che-plugin-registry-nightly/)](https://ci.centos.org/job/devtools-che-plugin-registry-nightly/)
+[![Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release&job=devtools-che-plugin-registry-release/)](https://ci.centos.org/job/devtools-che-plugin-registry-release/)
+[![Release Preview Build Status](https://ci.centos.org/buildStatus/icon?subject=release-preview&job=devtools-che-plugin-registry-release-preview/)](https://ci.centos.org/job/devtools-che-plugin-registry-release-preview/)
 
 # Eclipse Che plugin registry
 


### PR DESCRIPTION
### What does this PR do?
Updates badges to refer to the CI jobs they're monitoring, rather than just "build":

Old:
![Screenshot from 2019-08-28 11-41-45](https://user-images.githubusercontent.com/16168279/63870918-ee2a5e00-c988-11e9-98d4-46d9aaff9457.png)

New: 
![Screenshot from 2019-08-28 11-41-51](https://user-images.githubusercontent.com/16168279/63870927-f2567b80-c988-11e9-9b1c-42adec3b55d5.png)
