### PR TITLE
Fix missing category for AsciiDoctor plugin eclipse/che#14483

### DIFF
--- a/v3/plugins/joaompinto/vscode-asciidoctor/2.7.6/meta.yaml
+++ b/v3/plugins/joaompinto/vscode-asciidoctor/2.7.6/meta.yaml
@@ -7,6 +7,7 @@ displayName: AsciiDoc support
 title: AsciiDoctor Plugin.
 description: This extension provides a live preview, syntax highlighting and snippets for the AsciiDoc format using Asciidoctor flavor.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+category: Language
 repository: https://github.com/asciidoctor/asciidoctor-vscode
 spec:
   extensions:

--- a/v3/plugins/joaompinto/vscode-asciidoctor/latest/meta.yaml
+++ b/v3/plugins/joaompinto/vscode-asciidoctor/latest/meta.yaml
@@ -7,6 +7,7 @@ displayName: AsciiDoc support
 title: AsciiDoctor Plugin.
 description: This extension provides a live preview, syntax highlighting and snippets for the AsciiDoc format using Asciidoctor flavor.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+category: Language
 repository: https://github.com/asciidoctor/asciidoctor-vscode
 spec:
   extensions:


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

### What does this PR do?

fix master. The provided meta.yaml was missing the mandatory category attribute