### PR TITLE
to make it easier to run the check*.sh locally

### DIFF
--- a/scripts/check_plugins_location.sh
+++ b/scripts/check_plugins_location.sh
@@ -15,7 +15,7 @@
 set -e
 
 # shellcheck source=./scripts/util.sh
-source ./util.sh
+source "$(dirname "$0")/util.sh"
 
 readarray -d '' metas < <(find "$1" -name 'meta.yaml' -print0)
 for meta in "${metas[@]}"; do

--- a/scripts/check_plugins_viewer_mandatory_fields.sh
+++ b/scripts/check_plugins_viewer_mandatory_fields.sh
@@ -12,7 +12,7 @@
 set -e
 
 # shellcheck source=./scripts/util.sh
-source ./util.sh
+source "$(dirname "$0")/util.sh"
 
 readarray -d '' metas < <(find "$1" -name 'meta.yaml' -print0)
 


### PR DESCRIPTION
to make it easier to run the check*.sh scripts locally, use $(dirname "$0")/util.sh instead of just ./util.sh

Change-Id: I08ac3380ba9f2a8ea3489a4dc77befe052f0cf84
Signed-off-by: nickboldt <nboldt@redhat.com>