### PR TITLE
Update go plugin to 0.11.4 and uses docker images with go 1.12.9

### DIFF
--- a/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 publisher: ms-vscode
 name: go
-version: latest
+version: 0.11.4
 type: VS Code extension
 displayName: Go
 title: Rich Go language support


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### What does this PR do?
It updates go plugin to 0.11.4 and uses docker images with go 1.12.9

### Reference issue
https://github.com/eclipse/che/issues/13803

### Related PRs
https://github.com/eclipse/che-devfile-registry/pull/96
https://github.com/eclipse/che-theia/pull/443