### PR TITLE
Update plugin meta yaml structure definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,15 @@ spec:                  # spec (used to be che-plugin.yaml)
       env:               # list of env vars to set in sidecar
         - name:
           value:
-      command:           # optinal; definition of root process command inside container
+      command:           # optional; definition of root process command inside container
         - /bin/sh
-      args:              # optinal; list arguments for root process command inside container
+      args:              # optional; list arguments for root process command inside container
         - -c
           ./entrypoint.sh
       volumes:           # volumes required by plugin
         - mountPath:
           name:
-          persistVolume: # boolean; if true volume will be persisted, otherwise volume will be ephemeral; default value is true
+          ephemeral: # boolean; if true volume will be ephemeral, otherwise volume will be persisted
       ports:             # ports exposed by plugin (on the container)
         - exposedPort:
       commands:          # development commands available to plugin container
@@ -126,15 +126,15 @@ spec:                  # spec (used to be che-plugin.yaml)
       env:               # list of env vars to set in sidecar
         - name:
           value:
-      command:           # optinal; definition of root process command inside container
+      command:           # optional; definition of root process command inside container
         - /bin/sh
-      args:              # optinal; list arguments for root process command inside container
+      args:              # optional; list arguments for root process command inside container
         - -c
           ./entrypoint.sh
       volumes:           # volumes required by plugin
         - mountPath:
           name:
-          persistVolume: # boolean; if true volume will be persisted, otherwise volume will be ephemeral; default value is true
+          ephemeral: # boolean; if true volume will be ephemeral, otherwise volume will be persisted
       ports:             # ports exposed by plugin (on the container)
         - exposedPort:
       commands:          # development commands available to plugin container

--- a/README.md
+++ b/README.md
@@ -100,12 +100,44 @@ spec:                  # spec (used to be che-plugin.yaml)
       env:               # list of env vars to set in sidecar
         - name:
           value:
+      command:           # optinal; definition of root process command inside container
+        - /bin/sh
+      args:              # optinal; list arguments for root process command inside container
+        - -c
+          ./entrypoint.sh
       volumes:           # volumes required by plugin
         - mountPath:
           name:
+          persistVolume: # boolean; if true volume will be persisted, otherwise volume will be ephemeral; default value is true
       ports:             # ports exposed by plugin (on the container)
         - exposedPort:
-      commands:          # commands available to plugin container
+      commands:          # development commands available to plugin container
+        - name:
+          workingDir:
+          command:       # list of commands + arguments, e.g.:
+            - rm
+            - -rf
+            - /cache/.m2/repository
+      mountSources:      # boolean
+  initContainers:      # optional; init containers for sidecar plugin
+    - image:
+      name:              # name used for sidecar container
+      memorylimit:       # Kubernetes/OpenShift-spec memory limit string (e.g. "512Mi")
+      env:               # list of env vars to set in sidecar
+        - name:
+          value:
+      command:           # optinal; definition of root process command inside container
+        - /bin/sh
+      args:              # optinal; list arguments for root process command inside container
+        - -c
+          ./entrypoint.sh
+      volumes:           # volumes required by plugin
+        - mountPath:
+          name:
+          persistVolume: # boolean; if true volume will be persisted, otherwise volume will be ephemeral; default value is true
+      ports:             # ports exposed by plugin (on the container)
+        - exposedPort:
+      commands:          # development commands available to plugin container
         - name:
           workingDir:
           command:       # list of commands + arguments, e.g.:


### PR DESCRIPTION
### What does this PR do?
Update plugin meta yaml structure definition: defined commands and arguments for plugin container, defined initContainers field, defined persistVolume field.

### Referenced issue:
https://github.com/eclipse/che/issues/13387
**Depends on** https://github.com/eclipse/che-plugin-broker/pull/74 and https://github.com/eclipse/che/pull/14539