### PR TITLE
use vscode-python 2019.2.5558 instead of 2019.2.5433

### DIFF
--- a/v3/plugins/ms-python/python/2019.2.5558/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.2.5558/meta.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 publisher: ms-python
 name: python
-version: 2019.2.5433
+version: 2019.2.5558
 type: VS Code extension
 displayName: Python
 title: Python extension
@@ -16,4 +16,4 @@ spec:
       name: "vscode-python"
       memoryLimit: '512Mi'
   extensions:
-    - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-python/vsextensions/python/2019.2.5433/vspackage
+    - https://github.com/microsoft/vscode-python/releases/download/2019.2.5558/ms-python-release.vsix

--- a/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
@@ -16,4 +16,4 @@ spec:
       name: "vscode-python"
       memoryLimit: '512Mi'
   extensions:
-    - https://github.com/Microsoft/vscode-python/releases/download/2019.3.6558/ms-python-release.vsix
+    - https://github.com/microsoft/vscode-python/releases/download/2019.3.6558/ms-python-release.vsix


### PR DESCRIPTION
switch to vscode-python/releases/download/2019.2.5558 (in GH releases) vs. ms-python/vsextensions/python/2019.2.5433/vspackage (only in marketplace) (#14573)

Change-Id: I678ba2eb95ba2b2d1529b8d46d8b5aa0b9a10698
Signed-off-by: nickboldt <nboldt@redhat.com>