### PR TITLE
Add dependency analytics extension v0.0.13 to plugin registry

### DIFF
--- a/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 publisher: redhat
 name: dependency-analytics
-version: latest
+version: 0.0.13
 type: VS Code extension
 displayName: Dependency Analytics
 title: Insights about your application dependencies


### PR DESCRIPTION
### What does this PR do?

Adds meta information for Dependency Analytics Che Plugin v0.0.13/latest

Dependent PR :
eclipse/che-theia#469