### PR TITLE
Add firstPublishedDate for ASCIIDoctor plugin

### DIFF
--- a/v3/plugins/joaompinto/vscode-asciidoctor/2.7.6/meta.yaml
+++ b/v3/plugins/joaompinto/vscode-asciidoctor/2.7.6/meta.yaml
@@ -9,6 +9,7 @@ description: This extension provides a live preview, syntax highlighting and sni
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 category: Language
 repository: https://github.com/asciidoctor/asciidoctor-vscode
+firstPublicationDate: "2019-09-09"
 spec:
   extensions:
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/joaompinto/vsextensions/asciidoctor-vscode/2.7.6/vspackage

--- a/v3/plugins/joaompinto/vscode-asciidoctor/latest/meta.yaml
+++ b/v3/plugins/joaompinto/vscode-asciidoctor/latest/meta.yaml
@@ -9,6 +9,7 @@ description: This extension provides a live preview, syntax highlighting and sni
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 category: Language
 repository: https://github.com/asciidoctor/asciidoctor-vscode
+firstPublicationDate: "2019-09-09"
 spec:
   extensions:
   - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/joaompinto/vsextensions/asciidoctor-vscode/2.7.6/vspackage


### PR DESCRIPTION
### What does this PR do?
Adds `firstPublishedDate` for the AsciiDoctor plugin.