### PR TITLE
Add OpenShift Connector Che Plugin 0.1.0

### DIFF
--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.0/meta.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 publisher: redhat
 name: vscode-openshift-connector
-version: latest
+version: 0.1.0
 type: VS Code extension
 displayName: OpenShift Connector
 title: OpenShift Connector

--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.0/meta.yaml
@@ -9,8 +9,7 @@ description: Interacting with Red Hat OpenShift clusters and providing a streaml
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-plugin-registry/tree/master/v3/plugins/redhat/vscode-openshift-connector
 category: Other
-firstPublicationDate: "2019-03-11"
-latestUpdateDate: "2019-10-02"
+firstPublicationDate: "2019-10-08"
 spec:
   containers:
     - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.1.0:next"

--- a/v3/plugins/redhat/vscode-openshift-connector/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/latest/meta.yaml
@@ -9,8 +9,7 @@ description: Interacting with Red Hat OpenShift clusters and providing a streaml
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-plugin-registry/tree/master/v3/plugins/redhat/vscode-openshift-connector
 category: Other
-firstPublicationDate: "2019-03-11"
-latestUpdateDate: "2019-10-02"
+firstPublicationDate: "2019-10-08"
 spec:
   containers:
     - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.1.0:next"


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
- adds descriptor file for OpenShift Connector Che Plugin 0.1.0.
- points latest version to 0.1.0

Should be merged once `eclipse/che-remote-plugin-openshift-connector-0.1.0:next` image is published.
See https://github.com/eclipse/che-theia/pull/465
