### PR TITLE
Update java support

### DIFF
--- a/v3/plugins/redhat/java/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.50.0/meta.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+publisher: redhat
+name: java
+version: 0.50.0
+type: VS Code extension
+displayName: Language Support for Java(TM)
+title: Language Support for Java(TM) by Red Hat
+description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/redhat-developer/vscode-java
+category: Language
+firstPublicationDate: "2019-10-03"
+spec:
+  containers:
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+      name: vscode-java
+      memoryLimit: "1500Mi"
+      volumes:
+      - mountPath: "/home/theia/.m2"
+        name: m2
+  extensions:
+    - https://github.com/microsoft/vscode-java-debug/releases/download/0.20.0/vscode-java-debug-0.20.0.vsix
+    - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.50.0-1825.vsix

--- a/v3/plugins/redhat/java/latest/meta.yaml
+++ b/v3/plugins/redhat/java/latest/meta.yaml
@@ -10,12 +10,15 @@ description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle s
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-java
 category: Language
-firstPublicationDate: "2019-06-18"
+firstPublicationDate: "2019-10-03"
 spec:
   containers:
   - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
     name: vscode-java
     memoryLimit: "1500Mi"
+    volumes:
+    - mountPath: "/home/theia/.m2"
+      name: m2
   extensions:
-  - https://github.com/microsoft/vscode-java-debug/releases/download/0.19.0/vscode-java-debug-0.19.0.vsix
-  - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.46.0-1549.vsix
+  - https://github.com/microsoft/vscode-java-debug/releases/download/0.20.0/vscode-java-debug-0.20.0.vsix
+  - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.50.0-1825.vsix

--- a/v3/plugins/redhat/java11/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java11/0.50.0/meta.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+publisher: redhat
+name: java11
+version: 0.50.0
+type: VS Code extension
+displayName: Language Support for Java 11
+title: Language Support for Java(TM) by Red Hat
+description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/redhat-developer/vscode-java
+category: Language
+firstPublicationDate: "2019-10-03"
+spec:
+  containers:
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+      name: vscode-java
+      memoryLimit: "1500Mi"
+      volumes:
+      - mountPath: "/home/theia/.m2"
+        name: m2
+  extensions:
+    - https://github.com/microsoft/vscode-java-debug/releases/download/0.20.0/vscode-java-debug-0.20.0.vsix
+    - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.50.0-1825.vsix

--- a/v3/plugins/redhat/java11/latest/meta.yaml
+++ b/v3/plugins/redhat/java11/latest/meta.yaml
@@ -10,12 +10,15 @@ description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle s
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-java
 category: Language
-firstPublicationDate: "2019-06-18"
+firstPublicationDate: "2019-10-03"
 spec:
   containers:
   - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
     name: vscode-java
     memoryLimit: "1500Mi"
+    volumes:
+    - mountPath: "/home/theia/.m2"
+      name: m2
   extensions:
-  - https://github.com/microsoft/vscode-java-debug/releases/download/0.19.0/vscode-java-debug-0.19.0.vsix
-  - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.46.0-1549.vsix
+  - https://github.com/microsoft/vscode-java-debug/releases/download/0.20.0/vscode-java-debug-0.20.0.vsix
+  - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.50.0-1825.vsix

--- a/v3/plugins/redhat/java8/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.50.0/meta.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+publisher: redhat
+name: java8
+version: 0.50.0
+type: VS Code extension
+displayName: Language Support for Java 8
+title: Language Support for Java(TM) by Red Hat
+description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/redhat-developer/vscode-java
+category: Language
+firstPublicationDate: "2019-10-03"
+spec:
+  containers:
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+      name: vscode-java
+      memoryLimit: "1500Mi"
+      volumes:
+      - mountPath: "/home/theia/.m2"
+        name: m2
+  extensions:
+    - https://github.com/microsoft/vscode-java-debug/releases/download/0.20.0/vscode-java-debug-0.20.0.vsix
+    - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.50.0-1825.vsix

--- a/v3/plugins/redhat/java8/latest/meta.yaml
+++ b/v3/plugins/redhat/java8/latest/meta.yaml
@@ -10,12 +10,16 @@ description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle s
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-java
 category: Language
-firstPublicationDate: "2019-06-18"
+firstPublicationDate: "2019-10-03"
 spec:
   containers:
   - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
     name: vscode-java
     memoryLimit: "1500Mi"
+    volumes:
+    - mountPath: "/home/theia/.m2"
+      name: m2
   extensions:
-  - https://github.com/microsoft/vscode-java-debug/releases/download/0.19.0/vscode-java-debug-0.19.0.vsix
-  - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.46.0-1549.vsix
+  - https://github.com/microsoft/vscode-java-debug/releases/download/0.20.0/vscode-java-debug-0.20.0.vsix
+  - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.50.0-1825.vsix
+


### PR DESCRIPTION
### What does this PR do?
- Adds java plugin v0.50.0
- Updates latest java plugin
- Updates java-debug plugin to v0.20.0
- Adds `/home/theia/.m2` volume for java plugin

Related issue:
https://github.com/eclipse/che/issues/14649
https://github.com/eclipse/che/issues/13603