### PR TITLE
Use string value at `env.value` instead of boolean or integer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ spec:
     - name: HOSTED_PLUGIN_HOSTNAME
       value: 0.0.0.0
     - name: HOSTED_PLUGIN_PORT
-      value: 3130
+      value: "3130"
     volumes:
     - mountPath: /plugins
       name: plugins

--- a/v3/plugins/dirigiblelabs/dirigible/3.4.0/meta.yaml
+++ b/v3/plugins/dirigiblelabs/dirigible/3.4.0/meta.yaml
@@ -27,15 +27,15 @@ spec:
          - name: DIRIGIBLE_REPOSITORY_LOCAL_ROOT_FOLDER
            value: /projects/dirigible/repository
          - name: DIRIGIBLE_REPOSITORY_LOCAL_ROOT_FOLDER_IS_ABSOLUTE
-           value: true
+           value: "true"
          - name: DIRIGIBLE_REPOSITORY_SEARCH_ROOT_FOLDER
            value: /projects/dirigible/repository
          - name: DIRIGIBLE_REPOSITORY_SEARCH_ROOT_FOLDER_IS_ABSOLUTE
-           value: true
+           value: "true"
          - name: DIRIGIBLE_CMS_INTERNAL_ROOT_FOLDER
            value: /projects/dirigible/cms
          - name: DIRIGIBLE_CMS_INTERNAL_ROOT_FOLDER_IS_ABSOLUTE
-           value: true
+           value: "true"
          - name: DIRIGIBLE_DATABASE_H2_ROOT_FOLDER_DEFAULT
            value: /projects/dirigible/h2
          - name: DIRIGIBLE_DATABASE_H2_URL

--- a/v3/plugins/dirigiblelabs/dirigible/latest/meta.yaml
+++ b/v3/plugins/dirigiblelabs/dirigible/latest/meta.yaml
@@ -27,15 +27,15 @@ spec:
     - name: DIRIGIBLE_REPOSITORY_LOCAL_ROOT_FOLDER
       value: /projects/dirigible/repository
     - name: DIRIGIBLE_REPOSITORY_LOCAL_ROOT_FOLDER_IS_ABSOLUTE
-      value: true
+      value: "true"
     - name: DIRIGIBLE_REPOSITORY_SEARCH_ROOT_FOLDER
       value: /projects/dirigible/repository
     - name: DIRIGIBLE_REPOSITORY_SEARCH_ROOT_FOLDER_IS_ABSOLUTE
-      value: true
+      value: "true"
     - name: DIRIGIBLE_CMS_INTERNAL_ROOT_FOLDER
       value: /projects/dirigible/cms
     - name: DIRIGIBLE_CMS_INTERNAL_ROOT_FOLDER_IS_ABSOLUTE
-      value: true
+      value: "true"
     - name: DIRIGIBLE_DATABASE_H2_ROOT_FOLDER_DEFAULT
       value: /projects/dirigible/h2
     - name: DIRIGIBLE_DATABASE_H2_URL

--- a/v3/plugins/eclipse/che-theia/7.0.0-next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0-next/meta.yaml
@@ -55,7 +55,7 @@ spec:
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
-           value: 3130
+           value: "3130"
      volumes:
          - mountPath: "/plugins"
            name: plugins

--- a/v3/plugins/eclipse/che-theia/7.0.0-rc-3.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0-rc-3.0/meta.yaml
@@ -55,7 +55,7 @@ spec:
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
-           value: 3130
+           value: "3130"
      volumes:
          - mountPath: "/plugins"
            name: plugins

--- a/v3/plugins/eclipse/che-theia/7.0.0-rc-4.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0-rc-4.0/meta.yaml
@@ -55,7 +55,7 @@ spec:
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
-           value: 3130
+           value: "3130"
      volumes:
          - mountPath: "/plugins"
            name: plugins

--- a/v3/plugins/eclipse/che-theia/7.0.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.0.0/meta.yaml
@@ -55,7 +55,7 @@ spec:
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
-           value: 3130
+           value: "3130"
      volumes:
          - mountPath: "/plugins"
            name: plugins

--- a/v3/plugins/eclipse/che-theia/7.1.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.1.0/meta.yaml
@@ -55,7 +55,7 @@ spec:
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
-           value: 3130
+           value: "3130"
      volumes:
          - mountPath: "/plugins"
            name: plugins

--- a/v3/plugins/eclipse/che-theia/7.2.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.2.0/meta.yaml
@@ -55,7 +55,7 @@ spec:
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
-           value: 3130
+           value: "3130"
      volumes:
          - mountPath: "/plugins"
            name: plugins

--- a/v3/plugins/eclipse/che-theia/latest/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/latest/meta.yaml
@@ -55,7 +55,7 @@ spec:
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
-           value: 3130
+           value: "3130"
      volumes:
          - mountPath: "/plugins"
            name: plugins

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -55,7 +55,7 @@ spec:
          - name: HOSTED_PLUGIN_HOSTNAME
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
-           value: 3130
+           value: "3130"
      volumes:
          - mountPath: "/plugins"
            name: plugins


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Fixes to use string value.

All values in `*.env.value` should be typed to string.
Since it is obvious that runtimes treat it as string.
It's not good to use implicit type cast, IMO.