### PR TITLE
Fix CircleCI build to not make offline registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Build application Docker image
           command: |
-            docker build --cache-from=app -t app .
+            docker build --cache-from=app -t app --target registry .
       - run:
           name: Save Docker image layer cache
           command: |


### PR DESCRIPTION
### What does this PR do?
Update CircleCI config to build default registry instead of offline version.