### PR TITLE
feat(core): Add VS Camel K extension eclipse/che#14806

### DIFF
--- a/v3/plugins/redhat/vscode-camelk/0.0.9/meta.yaml
+++ b/v3/plugins/redhat/vscode-camelk/0.0.9/meta.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+publisher: redhat
+name: vscode-camelk
+version: 0.0.9
+type: VS Code extension
+displayName: Tooling for Apache Camel K
+title: Tooling for Apache Camel K
+description: VS Code support for Apache Camel K functionality
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/camel-tooling/vscode-camelk
+category: Language
+firstPublicationDate: '2019-07-10'
+spec:
+  containers:
+  - image: "eclipse/che-remote-plugin-camelk-0.0.9:next"
+    name: vscode-camelk
+    memoryLimit: "1G"
+  extensions:
+  - https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.9-86.vsix
+  - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.0/vscode-kubernetes-tools-1.0.0.vsix

--- a/v3/plugins/redhat/vscode-camelk/README.md
+++ b/v3/plugins/redhat/vscode-camelk/README.md
@@ -1,0 +1,15 @@
+# Eclipse Che Tooling Plugin for Apache Camel K
+
+## Setting up the access to a cluster from a Che Workspace
+
+The Plugin relies on `kubectl` to communicate with a Kubernetes cluster. The access to a cluster should be set up through a `kubeconfig`.
+
+`chectl` provides the [command](https://github.com/che-incubator/chectl#chectl-workspaceinject) that simplifies injecting local `kubeconfig` into a Che Workspace. When your Workspace is running, call the following command:
+```shell
+chectl workspace:inject -k
+```
+Then reload a browsers page to refresh the `Clusters` tree.
+
+## Setting up Camel K instance
+
+In case, the Kubernetes cluster on which the connection was setup doesn't contain Camel K. You can install it by opening a terminal and call `kamel install`.

--- a/v3/plugins/redhat/vscode-camelk/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-camelk/latest/meta.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+publisher: redhat
+name: vscode-camelk
+version: latest
+type: VS Code extension
+displayName: Tooling for Apache Camel K
+title: Tooling for Apache Camel K
+description: VS Code support for Apache Camel K functionality
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/camel-tooling/vscode-camelk
+category: Language
+firstPublicationDate: '2019-07-10'
+spec:
+  containers:
+  - image: "eclipse/che-remote-plugin-camelk-0.0.9:next"
+    name: vscode-camelk
+    memoryLimit: "1G"
+  extensions:
+  - https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.9-86.vsix
+  - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.0/vscode-kubernetes-tools-1.0.0.vsix


### PR DESCRIPTION
- requires a specific dockerfile with Kubectl and Kamel on cli.
- Add Kubernetes extension which is a required dependency of VS Code
Camel K tooling

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

### What does this PR do?

Add VS Code Tooling for Apache Camel in Che Plugin registry

~~/!\ it requires this other PR to be merged with Dockerfile published: https://github.com/eclipse/che-theia/pull/476~~ Dockerfile published