### PR TITLE
Avoid using character classes in schema, as suggested by docs

### DIFF
--- a/scripts/meta.yaml.schema
+++ b/scripts/meta.yaml.schema
@@ -6,44 +6,44 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "pattern": "^[^\\s]+$"
+      "pattern": "^[-._a-zA-Z0-9]+$"
     },
     "publisher": {
       "type": "string",
-      "pattern": "^[^\\s]+$"
+      "pattern": "^[-._a-zA-Z0-9]+$"
     },
     "name": {
       "type": "string",
-      "pattern": "^[^\\s]+$"
+      "pattern": "^[-._a-zA-Z0-9]+$"
     },
     "version": {
       "type": ["number", "string"],
-      "pattern": "^[^\\s]+$",
+      "pattern": "^[-._a-zA-Z0-9]+$",
       "minimum": 0
     },
     "title": {
       "type": "string",
-      "pattern": "[^\\s]+"
+      "pattern": "[-._a-zA-Z0-9]+"
     },
     "icon": {
       "type": "string",
-      "pattern": "[^\\s]+.svg[^.]*$"
+      "pattern": "[-._a-zA-Z0-9]+.svg[^.]*$"
     },
     "description": {
       "type": "string",
-      "pattern": "[^\\s]+"
+      "pattern": "[-._a-zA-Z0-9]+"
     },
     "repository": {
       "type": "string",
-      "pattern": "[^\\s]+"
+      "pattern": "[-._a-zA-Z0-9]+"
     },
     "firstPublicationDate": {
       "type": "string",
-      "pattern": "[^\\s]+"
+      "pattern": "[-._a-zA-Z0-9]+"
     },
     "latestUpdateDate": {
       "type": "string",
-      "pattern": "[^\\s]+"
+      "pattern": "[-._a-zA-Z0-9]+"
     },
     "spec": {
       "type": "object"


### PR DESCRIPTION
### What does this PR do?
Modifies the json schema to not use character classes, since they can be unreliable, and are [advised against](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions) in the jsonschema spec.