### PR TITLE
plugins must use docker.io or quay.io...

### DIFF
--- a/v3/plugins/redhat/rhamt/0.0.8/meta.yaml
+++ b/v3/plugins/redhat/rhamt/0.0.8/meta.yaml
@@ -24,7 +24,7 @@ spec:
     attributes:
       protocol: http
   containers:
-  - image: "windup3/rhamt-vscode-extension:java8"
+  - image: "docker.io/windup3/rhamt-vscode-extension:java8"
     name: rhamt-extension
     memoryLimit: 1500Mi
     ports:

--- a/v3/plugins/redhat/rhamt/latest/meta.yaml
+++ b/v3/plugins/redhat/rhamt/latest/meta.yaml
@@ -24,7 +24,7 @@ spec:
     attributes:
       protocol: http
   containers:
-  - image: "windup3/rhamt-vscode-extension:java8"
+  - image: "docker.io/windup3/rhamt-vscode-extension:java8"
     name: rhamt-extension
     memoryLimit: 1500Mi
     ports:

--- a/v3/plugins/redhat/vscode-camelk/0.0.9/meta.yaml
+++ b/v3/plugins/redhat/vscode-camelk/0.0.9/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-07-10'
 spec:
   containers:
-  - image: "eclipse/che-remote-plugin-camelk-0.0.9:next"
+  - image: "docker.io/eclipse/che-remote-plugin-camelk-0.0.9:next"
     name: vscode-camelk
     memoryLimit: "1G"
   extensions:

--- a/v3/plugins/redhat/vscode-camelk/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-camelk/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-07-10'
 spec:
   containers:
-  - image: "eclipse/che-remote-plugin-camelk-0.0.9:next"
+  - image: "docker.io/eclipse/che-remote-plugin-camelk-0.0.9:next"
     name: vscode-camelk
     memoryLimit: "1G"
   extensions:

--- a/v3/plugins/redhat/vscode-wsdl2rest/0.0.9/meta.yaml
+++ b/v3/plugins/redhat/vscode-wsdl2rest/0.0.9/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-02-26"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
       memoryLimit: "256Mi"
   extensions:
     - https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.9-16.vsix

--- a/v3/plugins/redhat/vscode-wsdl2rest/latest/meta.yaml
+++ b/v3/plugins/redhat/vscode-wsdl2rest/latest/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-02-26"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-runner-java8:next"
+    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
       memoryLimit: "256Mi"
   extensions:
     - https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.9-16.vsix


### PR DESCRIPTION
plugins must use docker.io or quay.io registry prefix so it's easier to airgap them later

Change-Id: I6ff9817ff5637d5f50b3c73df2d23064b53b199a
Signed-off-by: nickboldt <nboldt@redhat.com>