### PR TITLE
Add Kubernetes Che Plugin based on the VS Code Kubernetes extension 1.0.4

### DIFF
--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/README.md
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/README.md
@@ -1,0 +1,21 @@
+# Eclipse Che Kubernetes Tooling Plugin
+
+## Setting up the access to a cluster
+
+The Plugin relies on `kubectl` to communicate with a Kubernetes cluster. So, the access to a cluster should be set in a `kubeconfig` in plugin sidecar.
+
+`chectl` provides the [command](https://github.com/che-incubator/chectl#chectl-workspaceinject) that simplifies injecting local `kubeconfig` into a Che Workspace. When your Workspace is running, call the following command:
+```shell
+chectl workspace:inject -k
+```
+Then refresh the `Clusters` view.
+
+## Switching container image build tool
+
+The plugin provides [Buildah](https://github.com/containers/buildah) to enable building the images within your workspace. It's used by `Kubernetes: Run` and `Kubernetes: Debug` commands.
+To switch the plugin from the default build tool (Docker) to Buildah put the following setting to user preferences (`File - Settings - Open Preferences`):
+```
+"vs-kubernetes": {
+    "imageBuildTool": "Buildah"
+}
+```

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/meta.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+publisher: ms-kubernetes-tools
+name: vscode-kubernetes-tools
+version: 1.0.4
+type: VS Code extension
+displayName: Kubernetes
+title: Kubernetes Tools
+description: Develop, deploy and debug Kubernetes applications
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/Azure/vscode-kubernetes-tools
+category: Other
+firstPublicationDate: "2019-10-16"
+spec:
+  containers:
+    - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-1.0.4:next"
+      name: "vscode-kubernetes-tools"
+      memoryLimit: "1G"
+  extensions:
+    - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.4/vscode-kubernetes-tools-1.0.4.vsix

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/latest/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/latest/meta.yaml
@@ -9,11 +9,11 @@ description: Develop, deploy and debug Kubernetes applications
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/Azure/vscode-kubernetes-tools
 category: Other
-firstPublicationDate: '2019-05-15'
+firstPublicationDate: "2019-10-16"
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:next"
-    name: vscode-kubernetes-tools
-    memoryLimit: "1G"
+    - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-1.0.4:next"
+      name: "vscode-kubernetes-tools"
+      memoryLimit: "1G"
   extensions:
-  - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.0/vscode-kubernetes-tools-1.0.0.vsix
+    - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.4/vscode-kubernetes-tools-1.0.4.vsix


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?
Adds Kubernetes Tooling Che Plugin based on the latest VS Code Kubernetes extension 1.0.4 that includes [support of Buildah tool](https://github.com/Azure/vscode-kubernetes-tools/pull/559).

Depends on https://github.com/eclipse/che-theia/pull/493

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13316
