### PR TITLE
Adding openshift template for backwards compatibility required for the Hosted Che deployment

### DIFF
--- a/openshift/che-plugin-registry.yml
+++ b/openshift/che-plugin-registry.yml
@@ -1,0 +1,122 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: che-plugin-registry-service
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: che-plugin-registry
+    name: che-plugin-registry
+  spec:
+    replicas: 1
+    selector:
+      app: che-plugin-registry
+      deploymentconfig: che-plugin-registry
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: che-plugin-registry
+          deploymentconfig: che-plugin-registry
+      spec:
+        containers:
+        - image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: "${PULL_POLICY}"
+          name: che-plugin-registry
+          ports:
+          - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /plugins/
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /plugins/
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          envFrom:
+          - configMapRef:
+              name: che-plugin-registry
+              optional: true
+    triggers:
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: che-plugin-registry
+  spec:
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 8080
+    selector:
+      deploymentconfig: che-plugin-registry
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: che-plugin-registry
+  spec:
+    to:
+      kind: Service
+      name: che-plugin-registry
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: che-plugin-registry
+  data:
+    CHE_SIDECAR_CONTAINERS_REGISTRY_URL: ${CHE_SIDECAR_CONTAINERS_REGISTRY_URL}
+    CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION: ${CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION}
+    CHE_SIDECAR_CONTAINERS_REGISTRY_TAG: ${CHE_SIDECAR_CONTAINERS_REGISTRY_TAG}
+
+parameters:
+- name: IMAGE
+  value: quay.io/eclipse/che-plugin-registry
+  displayName: Eclipse Che plugin registry image
+  description: Che plugin registry Docker image. Defaults to eclipse/che-plugin-registry
+- name: IMAGE_TAG
+  value: nightly
+  displayName: Eclipse Che plugin registry version
+  description: Eclipse Che plugin registry version which defaults to nightly
+- name: MEMORY_LIMIT
+  value: 256Mi
+  displayName: Memory Limit
+  description: Maximum amount of memory the container can use. Defaults 256Mi
+- name: PULL_POLICY
+  value: Always
+  displayName: Eclipse Che plugin registry image pull policy
+  description: Always pull by default. Can be IfNotPresent
+- name: CHE_SIDECAR_CONTAINERS_REGISTRY_URL
+  displayName: Sidecar image registry URL
+  description: URL of docker registry containing plugin sidecar images; used to override sidecars in plugins
+- name: CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION
+  displayName: Sidecar image registry organization
+  description: Organization containing plugin sidecar images; used to override base images in plugins
+- name: CHE_SIDECAR_CONTAINERS_REGISTRY_TAG
+  displayName: Plugin sidecar images tag
+  description: Tag used for overridden sidecar images; used to override base images in plugins


### PR DESCRIPTION
### What does this PR do?

Adding openshift template for backwards compatibility required for the Hosted Che deployment (release-preview branch)
Alternative for https://github.com/openshiftio/saas-openshiftio/pull/1338
Deployment path has been changed in the https://github.com/eclipse/che-plugin-registry/pull/245

