### PR TITLE
Add redirect for resources to match one for plugins

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,6 +2,7 @@ Header set Access-Control-Allow-Origin "*"
 Header set Access-Control-Allow-Headers "Authorization"
 DirectoryIndex README.md
 Redirect temp /plugins /v3/plugins
+Redirect temp /resources /v3/resources
 <FilesMatch "\.(json|yaml)$">
     <IfModule mod_expires.c>
 	ExpiresActive Off


### PR DESCRIPTION
### What does this PR do?
Add redirect `/resources -> /v3/resources` to match the redirect for plugins.