### PR TITLE
Add list of external images to server when offline registry is built

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -41,6 +41,7 @@ CMD ["/usr/bin/run-httpd"]
 
 # Offline build: cache .theia and .vsix files in registry itself and update metas
 FROM builder AS offline-builder
+RUN ./list_referenced_images.sh v3 > /build/v3/external_images.txt
 RUN ./cache_artifacts.sh v3 && chmod -R g+rwX /build
 
 # Offline registry: copy updated meta.yamls and cached extensions

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -97,6 +97,7 @@ CMD ["/usr/local/bin/rhel.entrypoint.sh"]
 # Offline build: cache .theia and .vsix files in registry itself and update metas
 # multiple temp stages does not work in Brew
 FROM builder AS offline-builder
+RUN ./list_referenced_images.sh v3 > /build/v3/external_images.txt
 
 # built in Brew, use tarball in lookaside cache; built locally, comment this out
 # COPY v3.tgz /tmp/v3.tgz

--- a/build/scripts/list_referenced_images.sh
+++ b/build/scripts/list_referenced_images.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# List all images referenced in meta.yaml files
+#
+
+set -e
+
+readarray -d '' metas < <(find "$1" -name 'meta.yaml' -print0)
+yq -r '.spec.containers[]?.image' "${metas[@]}" | sort | uniq


### PR DESCRIPTION
### What does this PR do?
Adds building a list of externally-referenced images to the offline build to make it easier for users to know which images need to be pulled into a private registry.

Required for https://github.com/eclipse/che/issues/14866