### PR TITLE
move ./list_referenced_images.sh to run in...

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -29,6 +29,7 @@ RUN ./generate_latest_metas.sh v3 && \
     ./set_plugin_dates.sh v3 && \
     ./check_plugins_viewer_mandatory_fields.sh v3 && \
     ./index.sh v3 > /build/v3/plugins/index.json && \
+    ./list_referenced_images.sh v3 > /build/v3/external_images.txt && \
     chmod -R g+rwX /build
 
 # Build registry, copying meta.yamls and index.json from builder
@@ -41,7 +42,6 @@ CMD ["/usr/bin/run-httpd"]
 
 # Offline build: cache .theia and .vsix files in registry itself and update metas
 FROM builder AS offline-builder
-RUN ./list_referenced_images.sh v3 > /build/v3/external_images.txt
 RUN ./cache_artifacts.sh v3 && chmod -R g+rwX /build
 
 # Offline registry: copy updated meta.yamls and cached extensions

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -60,7 +60,8 @@ RUN ./generate_latest_metas.sh v3 && \
     ./set_plugin_dates.sh v3 && \
     ./check_plugins_viewer_mandatory_fields.sh v3 && \
     ./index.sh v3 > /build/v3/plugins/index.json && \
-    chmod -c -R g+rwX /build
+    ./list_referenced_images.sh v3 > /build/v3/external_images.txt && \
+    chmod -R g+rwX /build
 
 ################# 
 # PHASE THREE: create ubi8-minimal image with httpd
@@ -97,7 +98,6 @@ CMD ["/usr/local/bin/rhel.entrypoint.sh"]
 # Offline build: cache .theia and .vsix files in registry itself and update metas
 # multiple temp stages does not work in Brew
 FROM builder AS offline-builder
-RUN ./list_referenced_images.sh v3 > /build/v3/external_images.txt
 
 # built in Brew, use tarball in lookaside cache; built locally, comment this out
 # COPY v3.tgz /tmp/v3.tgz
@@ -111,7 +111,7 @@ RUN ./list_referenced_images.sh v3 > /build/v3/external_images.txt
 # 2. then add it to dist-git so it's part of this repo
 #    rhpkg new-sources root-local.tgz v3.tgz
 RUN if [ ! -f /tmp/v3.tgz ] || [ ${BOOTSTRAP} == "true" ]; then \
-      ./cache_artifacts.sh v3 && chmod -c -R g+rwX /build; \
+      ./cache_artifacts.sh v3 && chmod -R g+rwX /build; \
     else \
       # in Brew use /var/www/html/; in upstream/ offline-builder use /build/
       mkdir -p /build/v3/; tar xf /tmp/v3.tgz -C /build/v3/; rm -fr /tmp/v3.tgz;  \


### PR DESCRIPTION
move ./list_referenced_images.sh to run in builder step (doesn't need to run in offline-builder phase and WON'T RUN in Brew unless we copy the script to registry image too -- and this is simpler for Che, CRW, and Brew flavours)

Change-Id: Ie1380a05c7eebc1f0b3ba8d5ec9c8149345953db
Signed-off-by: nickboldt <nboldt@redhat.com>