### PR TITLE
Change the regex to replace registries that include colons

### DIFF
--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -34,7 +34,7 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \4 - Image name portion of image, e.g. quay.io/eclipse/(che-theia):tag
 #   \5 - Tag of image, e.g. quay.io/eclipse/che-theia:(tag)
 #   \6 - Optional quotation following image reference
-IMAGE_REGEX='([[:space:]]*"?)([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*):([._a-zA-Z0-9-]*)("?)'
+IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*):([._a-zA-Z0-9-]*)("?)'
 
 # We can't use the `-d` option for readarray because
 # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2


### PR DESCRIPTION
Signed-off-by: Tom George <tg82490@gmail.com>

### What does this PR do?
Fixes an issue where the plugin registry was not properly updating image references, causing the offline installation of che to try to pull limages from the wrong place

fixes https://github.com/eclipse/che/issues/14990