### PR TITLE
Replace 'eclipse/che-theia-endpoint-runtime' image

### DIFF
--- a/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-   - image: "docker.io/eclipse/che-theia-endpoint-runtime:next"
+   - image: "docker.io/eclipse/che-remote-plugin-node:next"
      name: "vscode-typescript"
      memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-theia-endpoint-runtime:next"
+  - image: "docker.io/eclipse/che-remote-plugin-node:next"
     name: vscode-typescript
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug/1.32.1/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug/1.32.1/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-theia-endpoint-runtime:next"
+    - image: "docker.io/eclipse/che-remote-plugin-node:next"
       name: vscode-node-debug-legacy
       memoryLimit: '256Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug/1.35.2/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug/1.35.2/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-theia-endpoint-runtime:next"
+  - image: "docker.io/eclipse/che-remote-plugin-node:next"
     name: vscode-node-debug-legacy
     memoryLimit: '256Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-theia-endpoint-runtime:next"
+    - image: "docker.io/eclipse/che-remote-plugin-node:next"
       name: vscode-node-debug
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-theia-endpoint-runtime:next"
+  - image: "docker.io/eclipse/che-remote-plugin-node:next"
     name: vscode-node-debug
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-theia-endpoint-runtime:next"
+    - image: "docker.io/eclipse/che-remote-plugin-node:next"
       name: vscode-yaml
       memoryLimit: "256Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-theia-endpoint-runtime:next"
+    - image: "docker.io/eclipse/che-remote-plugin-node:next"
       name: vscode-yaml
       memoryLimit: "256Mi"
   extensions:


### PR DESCRIPTION
### What does this PR do?
Replace `eclipse/che-theia-endpoint-runtime` image with `eclipse/che-remote-plugin-node` image

`eclipse/che-theia-endpoint-runtime` - is deprecated, see [che-theia PR](https://github.com/eclipse/che-theia/pull/521 )