### PR TITLE
Make sure theia-remote-runtime-binary image is included in airgap

### DIFF
--- a/build/scripts/list_referenced_images.sh
+++ b/build/scripts/list_referenced_images.sh
@@ -13,4 +13,4 @@
 set -e
 
 readarray -d '' metas < <(find "$1" -name 'meta.yaml' -print0)
-yq -r '.spec.containers[]?.image' "${metas[@]}" | sort | uniq
+yq -r '..|.image?' "${metas[@]}" | grep -v 'null' | sort | uniq

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -69,7 +69,7 @@ spec:
      memoryLimit: "512M"
   initContainers:
   - name: remote-runtime-injector
-    image: eclipse/che-theia-endpoint-runtime-binary:next
+    image: docker.io/eclipse/che-theia-endpoint-runtime-binary:next
     volumes:
       - mountPath: "/remote-endpoint"
         name: remote-endpoint

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.4/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.4/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-08-07"
 spec:
   containers:
-  - image: eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next
+  - image: docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:


### PR DESCRIPTION
### What does this PR do?
Make sure that init container added for remote runtime injection is included in existing airgap functionality.

- Update scripts to handle updated devfile structure (initcontainers)
- Update metas to all have registry in image references.