### PR TITLE
Remove /projects mount on codeserver, since mountSources is set to true

### DIFF
--- a/v3/plugins/cdr/code-server/2.1523-vsc1.38.1/meta.yaml
+++ b/v3/plugins/cdr/code-server/2.1523-vsc1.38.1/meta.yaml
@@ -26,10 +26,6 @@ spec:
          - exposedPort: 9000
      memoryLimit: "1024M"
      volumes:
-        - mountPath: '/projects'
-          name: 'projects'
-          ephemeral: true
-
         - mountPath: '/home/coder/.local/share/code-server'
           name: 'user-data'
 

--- a/v3/plugins/cdr/code-server/next/meta.yaml
+++ b/v3/plugins/cdr/code-server/next/meta.yaml
@@ -26,10 +26,6 @@ spec:
          - exposedPort: 9000
      memoryLimit: "1024M" 
      volumes:
-        - mountPath: '/projects'
-          name: 'projects'
-          ephemeral: true
-
         - mountPath: '/home/coder/.local/share/code-server'
           name: 'user-data'
 


### PR DESCRIPTION
### What does this PR do?
The codeserver editor has both `mountSources: true` and an explicit volume mount for `/projects`, which causes Che to create an invalid deployment: 

```
Deployment.apps "<workspace-id>.che-workspace-pod" is invalid: spec.template.spec.containers[0].volumeMounts[3].mountPath: Invalid value: "/projects": must be unique.
```

This PR removes the explicit `/projects` volume mount.