### PR TITLE
Add ibuziuk to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @vparfonov @l0rd @rhopp @skabashnyuk @amisevsk @nickboldt
+* @vparfonov @l0rd @rhopp @skabashnyuk @amisevsk @nickboldt @ibuziuk


### PR DESCRIPTION
### What does this PR do?
Add @ibuziuk as codeowner, to help with pushing through smaller changes that still require codeowner approval.