### PR TITLE
Use nightly version che-machine-exec from centos Ci.

### DIFF
--- a/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 publisher: eclipse
 name: che-machine-exec-plugin
-version: next
+version: nightly
 type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
@@ -9,7 +9,7 @@ description: Che Plug-in with che-machine-exec service to provide creation termi
   or tasks for Eclipse CHE workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
-firstPublicationDate: "2019-02-05"
+firstPublicationDate: "2019-11-7"
 category: Other
 spec:
   endpoints:
@@ -24,6 +24,6 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: che-machine-exec
-     image: "docker.io/eclipse/che-machine-exec:next"
+     image: "quay.io/eclipse/che-machine-exec:nightly"
      ports:
        - exposedPort: 4444

--- a/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
@@ -9,7 +9,7 @@ description: Che Plug-in with che-machine-exec service to provide creation termi
   or tasks for Eclipse CHE workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
-firstPublicationDate: "2019-11-7"
+firstPublicationDate: "2019-11-07"
 category: Other
 spec:
   endpoints:


### PR DESCRIPTION
### What does this PR do?
Use nightly version che-machine-exec from centos Ci. Remove next tag from Codenvy CI.

### Referenced issue:
https://github.com/eclipse/che/issues/14887

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
