### PR TITLE
Use nightly version che-machine-exec from centos Ci. (#290)

### DIFF
--- a/v3/plugins/eclipse/che-machine-exec-plugin/next/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/next/meta.yaml
@@ -10,6 +10,9 @@ description: Che Plug-in with che-machine-exec service to provide creation termi
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-02-05"
+deprecate:
+  automigrate: true
+  migrateTo: eclipse/che-machine-exec-plugin/nightly
 category: Other
 spec:
   endpoints:
@@ -24,6 +27,6 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: che-machine-exec
-     image: "docker.io/eclipse/che-machine-exec:next"
+     image: "quay.io/eclipse/che-machine-exec:nightly"
      ports:
        - exposedPort: 4444

--- a/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+publisher: eclipse
+name: che-machine-exec-plugin
+version: nightly
+type: Che Plugin
+displayName: Che machine-exec Service
+title: Che machine-exec Service Plugin
+description: Che Plug-in with che-machine-exec service to provide creation terminal
+  or tasks for Eclipse CHE workspace containers.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2019-11-07"
+category: Other
+spec:
+  endpoints:
+   -  name: "che-machine-exec"
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: ws
+        type: terminal
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+   - name: che-machine-exec
+     image: "quay.io/eclipse/che-machine-exec:nightly"
+     ports:
+       - exposedPort: 4444


### PR DESCRIPTION
### What does this PR do?
* Use nightly version che-machine-exec from centos Ci.
Use nightly version che-machine-exec from centos Ci.

### Referenced issue
https://github.com/eclipse/che/issues/14887

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
