### PR TITLE
add trailing slash in the self link to avoid unnecessary redirects

### DIFF
--- a/build/scripts/index.sh
+++ b/build/scripts/index.sh
@@ -24,6 +24,6 @@ yq -sS 'map(
     "\(.publisher)/\(.name)/\(.version)" as $id |
     {
         $id, displayName, version, type, name, description, publisher,
-        links: {self: "\($PLUGINS_DIR)/\($id)"}
+        links: {self: "\($PLUGINS_DIR)/\($id)/"}
     } + if has("deprecate") then {deprecate} else null end ) |
     sort_by(.id)' "${metas[@]}" --arg "PLUGINS_DIR" "$PLUGINS_DIR"


### PR DESCRIPTION
### What does this PR do?
 - add trailing slash in the self link to avoid unnecessary redirects
- Workaround for https://github.com/eclipse/che/issues/15189