### PR TITLE
Ensure all image references have registry part

### DIFF
--- a/v3/plugins/eclipse/che-theia/7.3.1/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.3.1/meta.yaml
@@ -69,7 +69,7 @@ spec:
      memoryLimit: "512M"
   initContainers:
   - name: remote-runtime-injector
-    image: eclipse/che-theia-endpoint-runtime-binary:7.3.1
+    image: "docker.io/eclipse/che-theia-endpoint-runtime-binary:7.3.1"
     volumes:
       - mountPath: "/remote-endpoint"
         name: remote-endpoint

--- a/v3/plugins/eclipse/che-theia/7.4.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.4.0/meta.yaml
@@ -69,7 +69,7 @@ spec:
      memoryLimit: "512M"
   initContainers:
   - name: remote-runtime-injector
-    image: eclipse/che-theia-endpoint-runtime-binary:7.4.0
+    image: "docker.io/eclipse/che-theia-endpoint-runtime-binary:7.4.0"
     volumes:
       - mountPath: "/remote-endpoint"
         name: remote-endpoint

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -69,7 +69,7 @@ spec:
      memoryLimit: "512M"
   initContainers:
   - name: remote-runtime-injector
-    image: docker.io/eclipse/che-theia-endpoint-runtime-binary:next
+    image: "docker.io/eclipse/che-theia-endpoint-runtime-binary:next"
     volumes:
       - mountPath: "/remote-endpoint"
         name: remote-endpoint

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.4/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.4/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-08-07"
 spec:
   containers:
-  - image: docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next
+  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:


### PR DESCRIPTION
## What does this PR do?
Makes sure all images have a registry included (i.e. replace `eclipse/image` with `docker.io/eclipse/image`. This is required for various scripts, including airgap (so that registry can be overridden).