### PR TITLE
fix(theia-endpoint): Use tagged images for the theia plug-ins sidecar

### DIFF
--- a/v3/plugins/broadcommfd/cobol-language-support/0.8.3/meta.yaml
+++ b/v3/plugins/broadcommfd/cobol-language-support/0.8.3/meta.yaml
@@ -11,7 +11,7 @@ repository: https://github.com/eclipse/che-che4z-lsp-for-cobol
 category: Language
 spec:
   containers:
-    - image: eclipse/che-remote-plugin-runner-java8:7.3.0
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       memoryLimit: 512Mi
   extensions:
     - https://github.com/eclipse/che-che4z/releases/download/1.0.0/cobol-language-support-0.8.3.vsix

--- a/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
+++ b/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
@@ -15,7 +15,7 @@ deprecate:
   migrateTo: redhat/vscode-apache-camel/latest
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
       name: vscode-apache-camel
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
+++ b/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-08-06'
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-clang-8:next"
+    - image: "quay.io/eclipse/che-sidecar-clang:8-2ac897d"
       name: cpp-plugins
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/theia-dev/0.0.1/meta.yaml
+++ b/v3/plugins/che-incubator/theia-dev/0.0.1/meta.yaml
@@ -19,7 +19,7 @@ spec:
       protocol: http
   containers:
    - name: theia-dev
-     image: "docker.io/eclipse/che-theia-dev:nightly"
+     image: "docker.io/eclipse/che-theia-dev:next"
      commands:
        - name: uname
          workingDir: "$(project)"

--- a/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-   - image: "docker.io/eclipse/che-remote-plugin-node:next"
+   - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
      name: "vscode-typescript"
      memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-node:next"
+  - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
     name: vscode-typescript
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-03-11"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-0.1.17:next"
+    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:0.1.17-83aa850"
       name: "vscode-kubernetes-tools"
       memoryLimit: "1G"
   extensions:

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-05-15"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-1.0.0:next"
+    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.0-a2be59e"
       name: "vscode-kubernetes-tools"
       memoryLimit: "1G"
   extensions:

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-10-16"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-kubernetes-tooling-1.0.4:next"
+    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.4-be0639e"
       name: "vscode-kubernetes-tools"
       memoryLimit: "1G"
   extensions:

--- a/v3/plugins/ms-python/python/2019.2.5558/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.2.5558/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-03-05"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-python-3.7.3:next"
+    - image: "quay.io/eclipse/che-sidecar-python:3.7.3-7db4b1f"
       name: "vscode-python"
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-23"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-python-3.7.3:next"
+    - image: "quay.io/eclipse/che-sidecar-python:3.7.3-7db4b1f"
       name: "vscode-python"
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-python-3.7.3:next"
+  - image: "quay.io/eclipse/che-sidecar-python:3.7.3-7db4b1f"
     name: vscode-python
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-vscode/go/0.11.0/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.11.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-go-1.10.7:next"
+    - image: "quay.io/eclipse/che-sidecar-go:1.10.7-2d3c3fc"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-09-19'
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-go-1.12.9:next"
+    - image: "quay.io/eclipse/che-sidecar-go:1.12.9-3414491"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-21"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-go-1.10.7:next"
+    - image: "quay.io/eclipse/che-sidecar-go:1.10.7-2d3c3fc"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/node-debug/1.32.1/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug/1.32.1/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-node:next"
+    - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
       name: vscode-node-debug-legacy
       memoryLimit: '256Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug/1.35.2/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug/1.35.2/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-node:next"
+  - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
     name: vscode-node-debug-legacy
     memoryLimit: '256Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-node:next"
+    - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
       name: vscode-node-debug
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-node:next"
+  - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
     name: vscode-node-debug
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/pizzafactory/vscode-libra-move/0.0.10/meta.yaml
+++ b/v3/plugins/pizzafactory/vscode-libra-move/0.0.10/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 repository: https://github.com/pizzafactory-contorno/vscode-libra-move/
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-libra-move
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/pizzafactory/xtend-lang/0.1.0/meta.yaml
+++ b/v3/plugins/pizzafactory/xtend-lang/0.1.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 repository: https://github.com/PizzaFactory/xtend-ide-extensions/
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-xtend-lang
       memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/pizzafactory/xtext-lang/0.4.0/meta.yaml
+++ b/v3/plugins/pizzafactory/xtext-lang/0.4.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 repository: https://github.com/PizzaFactory/xtext-ide-extensions/
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-xtext-lang
       memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-03-13"
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:next"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.2/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-19"
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:next"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.4/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.4/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-08-07"
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:7.0.0-next"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.5/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.5/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-10-01"
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:next"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-dotnet-2.2.105:next"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
     name: theia-netcoredbg
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/dependency-analytics/0.0.12/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/0.0.12/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: '2018-10-03'
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-dependency-analytics-0.0.12:next"
+    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.12-fd28802"
       memoryLimit: "512Mi"
   extensions:
     - https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.0.12/redhat.fabric8-analytics-0.0.12.vsix

--- a/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: '2019-09-12'
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-dependency-analytics-0.0.13:next"
+    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-83f9a11"
       name: dependency-analytics
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.38.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.38.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.43.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.43.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-25"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.45.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.45.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-05-27"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.46.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.50.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-10-03"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-java
       memoryLimit: "1500Mi"
       volumes:

--- a/v3/plugins/redhat/java11/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java11/0.46.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java11/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java11/0.50.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-10-03"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
       name: vscode-java
       memoryLimit: "1500Mi"
       volumes:

--- a/v3/plugins/redhat/java8/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.46.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java8/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.50.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-10-03"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-java
       memoryLimit: "1500Mi"
       volumes:

--- a/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
+++ b/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-php7:next"
+    - image: "quay.io/eclipse/che-sidecar-php:7-295ec32"
       name: php-debugger
   extensions:
     - https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix

--- a/v3/plugins/redhat/php/1.0.13/meta.yaml
+++ b/v3/plugins/redhat/php/1.0.13/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-php7:next"
+    - image: "quay.io/eclipse/che-sidecar-php:7-295ec32"
       name: php-intelephense
       memoryLimit: "1000Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-apache-camel/0.0.16/meta.yaml
+++ b/v3/plugins/redhat/vscode-apache-camel/0.0.16/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2018-04-23'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+  - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
     name: vscode-apache-camel
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-apache-camel/0.0.18/meta.yaml
+++ b/v3/plugins/redhat/vscode-apache-camel/0.0.18/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2018-04-23'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+  - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
     name: vscode-apache-camel
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-camelk/0.0.10/meta.yaml
+++ b/v3/plugins/redhat/vscode-camelk/0.0.10/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-07-10'
 spec:
   containers:
-  - image: "eclipse/che-remote-plugin-camelk-0.0.10:next"
+  - image: "quay.io/eclipse/che-sidecar-camelk:0.0.10-966607d"
     name: vscode-camelk
     memoryLimit: "1G"
   extensions:

--- a/v3/plugins/redhat/vscode-camelk/0.0.9/meta.yaml
+++ b/v3/plugins/redhat/vscode-camelk/0.0.9/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-07-10'
 spec:
   containers:
-  - image: "docker.io/eclipse/che-remote-plugin-camelk-0.0.9:next"
+  - image: "quay.io/eclipse/che-sidecar-camelk:0.0.9-b94109d"
     name: vscode-camelk
     memoryLimit: "1G"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.17/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.17/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-03-11"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.0.17:next"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.17-cdaa03d"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.19/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.19/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.0.17:next"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.17-cdaa03d"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.21/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.21/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-05-22"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.0.21:next"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.21-0a79485"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.0/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-10-08"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.1.0:next"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.0-72ccd49"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.1/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.1/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-10-08"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-openshift-connector-0.1.1:next"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.1-3cc32f7"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-wsdl2rest/0.0.9/meta.yaml
+++ b/v3/plugins/redhat/vscode-wsdl2rest/0.0.9/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-02-26"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       memoryLimit: "256Mi"
   extensions:
     - https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.9-16.vsix

--- a/v3/plugins/redhat/vscode-xml/0.3.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.3.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
       name: vscode-xml
       memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-xml/0.5.1/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.5.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
       name: vscode-xml
       memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-xml/0.7.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.7.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-17"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
       name: vscode-xml
       memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-xml/0.9.1/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.9.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-10-28"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java11:next"
+    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
       name: vscode-xml
       memoryLimit: "768Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-node:next"
+    - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
       name: vscode-yaml
       memoryLimit: "256Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-node:next"
+    - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
       name: vscode-yaml
       memoryLimit: "256Mi"
   extensions:

--- a/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/0.0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Linter
 repository: https://www.sonarlint.org/
 spec:
   containers:
-    - image: "docker.io/eclipse/che-remote-plugin-runner-java8:next"
+    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
       name: vscode-sonarlint
       memoryLimit: "512Mi"
   extensions:


### PR DESCRIPTION
### What does this PR do?
As we don't need anymore to follow Che-Theia lifecycle as the endpoint binary is not anymore inside the container, we can use fixed tagged images for plug-ins sidecars.

Part of https://github.com/eclipse/che/issues/15109

Change-Id: I1f26ffe38c8cb75d8048e99d11b3e5b12790cc53
Signed-off-by: Florent Benoit <fbenoit@redhat.com>