### PR TITLE
Update registry to use newer images from che-dockerfiles

### DIFF
--- a/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
+++ b/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-08-06'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-clang:8-2ac897d"
+    - image: "quay.io/eclipse/che-sidecar-clang:8-83adb3a"
       name: cpp-plugins
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.30.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-19"
 spec:
   containers:
-   - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
+   - image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
      name: "vscode-typescript"
      memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-node:10-09f63ac"
+  - image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
     name: vscode-typescript
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-03-11"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:0.1.17-83aa850"
+    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:0.1.17-51a0085"
       name: "vscode-kubernetes-tools"
       memoryLimit: "1G"
   extensions:

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-05-15"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.0-a2be59e"
+    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.0-58ad4e2"
       name: "vscode-kubernetes-tools"
       memoryLimit: "1G"
   extensions:

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-10-16"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.4-be0639e"
+    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.4-a46d022"
       name: "vscode-kubernetes-tools"
       memoryLimit: "1G"
   extensions:

--- a/v3/plugins/ms-python/python/2019.2.5558/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.2.5558/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-03-05"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-python:3.7.3-7db4b1f"
+    - image: "quay.io/eclipse/che-sidecar-python:3.7.3-8f39348"
       name: "vscode-python"
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.3.6558/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-23"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-python:3.7.3-7db4b1f"
+    - image: "quay.io/eclipse/che-sidecar-python:3.7.3-8f39348"
       name: "vscode-python"
       memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
@@ -13,7 +13,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-python:3.7.3-7db4b1f"
+  - image: "quay.io/eclipse/che-sidecar-python:3.7.3-8f39348"
     name: vscode-python
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/ms-vscode/go/0.11.0/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.11.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-go:1.10.7-2d3c3fc"
+    - image: "quay.io/eclipse/che-sidecar-go:1.10.7-c05dfb0"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-09-19'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-go:1.12.9-3414491"
+    - image: "quay.io/eclipse/che-sidecar-go:1.12.9-304cd66"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.9.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-21"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-go:1.10.7-2d3c3fc"
+    - image: "quay.io/eclipse/che-sidecar-go:1.10.7-c05dfb0"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-03-13"
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.2/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.2/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-19"
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.4/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.4/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-08-07"
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.5/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.5/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-10-01"
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78"
     name: theia-omnisharp
     memoryLimit: "1024Mi"
   extensions:

--- a/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.1/meta.yaml
@@ -12,7 +12,7 @@ category: Debugger
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-0f34951"
+  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78"
     name: theia-netcoredbg
     memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/dependency-analytics/0.0.12/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/0.0.12/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: '2018-10-03'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.12-fd28802"
+    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.12-d478351"
       memoryLimit: "512Mi"
   extensions:
     - https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.0.12/redhat.fabric8-analytics-0.0.12.vsix

--- a/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: '2019-09-12'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-83f9a11"
+    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-a38cb0c"
       name: dependency-analytics
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.38.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.38.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-02-20"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
+    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.43.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.43.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-25"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
+    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.45.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.45.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-05-27"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
+    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.46.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
+    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.50.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-10-03"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
+    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
       name: vscode-java
       memoryLimit: "1500Mi"
       volumes:

--- a/v3/plugins/redhat/java8/0.46.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.46.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-06-18"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
+    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
       name: vscode-java
       memoryLimit: "1500Mi"
   extensions:

--- a/v3/plugins/redhat/java8/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.50.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-10-03"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-fac2415"
+    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
       name: vscode-java
       memoryLimit: "1500Mi"
       volumes:

--- a/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
+++ b/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-php:7-295ec32"
+    - image: "quay.io/eclipse/che-sidecar-php:7-5c5ecc5"
       name: php-debugger
   extensions:
     - https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix

--- a/v3/plugins/redhat/php/1.0.13/meta.yaml
+++ b/v3/plugins/redhat/php/1.0.13/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-php:7-295ec32"
+    - image: "quay.io/eclipse/che-sidecar-php:7-5c5ecc5"
       name: php-intelephense
       memoryLimit: "1000Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.17/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.17/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-03-11"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.17-cdaa03d"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.17-eec0eef"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.19/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.19/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.17-cdaa03d"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.17-eec0eef"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.0.21/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.0.21/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-05-22"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.21-0a79485"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.0.21-b582160"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.0/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-10-08"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.0-72ccd49"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.0-5460589"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.1/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.1/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2019-10-08"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.1-3cc32f7"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.1-9ab314d"
       name: "vscode-openshift-connector"
       memoryLimit: "512Mi"
   extensions:


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Updates docker images to the latest version.

Related to: https://github.com/eclipse/che/issues/15402