### PR TITLE
Update reference for node-debug2 extension

### DIFF
--- a/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.31.6/meta.yaml
@@ -10,6 +10,9 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/Microsoft/vscode-node-debug2
 category: Debugger
 firstPublicationDate: "2019-02-19"
+deprecate:
+  automigrate: true
+  migrateTo: ms-vscode/node-debug2/latest
 spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"

--- a/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
@@ -17,4 +17,4 @@ spec:
     name: vscode-node-debug
     memoryLimit: '512Mi'
   extensions:
-  - https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/node-debug2/1.33.0/vspackage
+  - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-node-debug2/node-debug2-1.33.0.vsix


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

### What does this PR do?
- deprecate old node-debug2 version 1.31.6 
- update newest node-debu2 version 1.33.0 to replace link from vscode marketplace with dl.jboss.org link