### PR TITLE
Add 7.3.2 and 7.3.3 versions of che-theia/che-machine-exec

### DIFF
--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.3.2/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.3.2/meta.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+publisher: eclipse
+name: che-machine-exec-plugin
+version: 7.3.2
+type: Che Plugin
+displayName: Che machine-exec Service
+title: Che machine-exec Service Plugin
+description: Che Plug-in with che-machine-exec service to provide creation terminal
+  or tasks for Eclipse CHE workspace containers.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2019-11-14"
+category: Other
+spec:
+  endpoints:
+   -  name: "che-machine-exec"
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: ws
+        type: terminal
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+   - name: che-machine-exec
+     image: "quay.io/eclipse/che-machine-exec:7.3.2"
+     ports:
+       - exposedPort: 4444

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.3.3/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.3.3/meta.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+publisher: eclipse
+name: che-machine-exec-plugin
+version: 7.3.3
+type: Che Plugin
+displayName: Che machine-exec Service
+title: Che machine-exec Service Plugin
+description: Che Plug-in with che-machine-exec service to provide creation terminal
+  or tasks for Eclipse CHE workspace containers.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2019-12-04"
+category: Other
+spec:
+  endpoints:
+   -  name: "che-machine-exec"
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: ws
+        type: terminal
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+   - name: che-machine-exec
+     image: "quay.io/eclipse/che-machine-exec:7.3.3"
+     ports:
+       - exposedPort: 4444

--- a/v3/plugins/eclipse/che-theia/7.3.2/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.3.2/meta.yaml
@@ -1,0 +1,81 @@
+apiVersion: v2
+publisher: eclipse
+name: che-theia
+version: 7.3.2
+type: Che Editor
+displayName: theia-ide
+title: Eclipse Theia for Eclipse Che
+description: Eclipse Theia
+icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
+category: Editor
+repository: https://github.com/eclipse/che-theia
+firstPublicationDate: "2019-11-14"
+spec:
+  endpoints:
+   -  name: "theia"
+      public: true
+      targetPort: 3100
+      attributes:
+        protocol: http
+        type: ide
+        secure: true
+        cookiesAuthEnabled: true
+        discoverable: false
+   -  name: "theia-dev"
+      public: true
+      targetPort: 3130
+      attributes:
+        protocol: http
+        type: ide-dev
+        discoverable: false
+   -  name: "theia-redirect-1"
+      public: true
+      targetPort: 13131
+      attributes:
+        protocol: http
+        discoverable: false
+   -  name: "theia-redirect-2"
+      public: true
+      targetPort: 13132
+      attributes:
+        protocol: http
+        discoverable: false
+   -  name: "theia-redirect-3"
+      public: true
+      targetPort: 13133
+      attributes:
+        protocol: http
+        discoverable: false
+  containers:
+   - name: theia-ide
+     image: "docker.io/eclipse/che-theia:7.3.2"
+     env:
+         - name: THEIA_PLUGINS
+           value: local-dir:///plugins
+         - name: HOSTED_PLUGIN_HOSTNAME
+           value: 0.0.0.0
+         - name: HOSTED_PLUGIN_PORT
+           value: "3130"
+     volumes:
+         - mountPath: "/plugins"
+           name: plugins
+     mountSources: true
+     ports:
+         - exposedPort: 3100
+         - exposedPort: 3130
+         - exposedPort: 13131
+         - exposedPort: 13132
+         - exposedPort: 13133
+     memoryLimit: "512M"
+  initContainers:
+  - name: remote-runtime-injector
+    image: eclipse/che-theia-endpoint-runtime-binary:7.3.2
+    volumes:
+      - mountPath: "/remote-endpoint"
+        name: remote-endpoint
+        ephemeral: true
+    env:
+      - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+        value: /remote-endpoint/plugin-remote-endpoint
+      - name: REMOTE_ENDPOINT_VOLUME_NAME
+        value: remote-endpoint

--- a/v3/plugins/eclipse/che-theia/7.3.3/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.3.3/meta.yaml
@@ -1,0 +1,81 @@
+apiVersion: v2
+publisher: eclipse
+name: che-theia
+version: 7.3.3
+type: Che Editor
+displayName: theia-ide
+title: Eclipse Theia for Eclipse Che
+description: Eclipse Theia
+icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
+category: Editor
+repository: https://github.com/eclipse/che-theia
+firstPublicationDate: "2019-12-04"
+spec:
+  endpoints:
+   -  name: "theia"
+      public: true
+      targetPort: 3100
+      attributes:
+        protocol: http
+        type: ide
+        secure: true
+        cookiesAuthEnabled: true
+        discoverable: false
+   -  name: "theia-dev"
+      public: true
+      targetPort: 3130
+      attributes:
+        protocol: http
+        type: ide-dev
+        discoverable: false
+   -  name: "theia-redirect-1"
+      public: true
+      targetPort: 13131
+      attributes:
+        protocol: http
+        discoverable: false
+   -  name: "theia-redirect-2"
+      public: true
+      targetPort: 13132
+      attributes:
+        protocol: http
+        discoverable: false
+   -  name: "theia-redirect-3"
+      public: true
+      targetPort: 13133
+      attributes:
+        protocol: http
+        discoverable: false
+  containers:
+   - name: theia-ide
+     image: "docker.io/eclipse/che-theia:7.3.3"
+     env:
+         - name: THEIA_PLUGINS
+           value: local-dir:///plugins
+         - name: HOSTED_PLUGIN_HOSTNAME
+           value: 0.0.0.0
+         - name: HOSTED_PLUGIN_PORT
+           value: "3130"
+     volumes:
+         - mountPath: "/plugins"
+           name: plugins
+     mountSources: true
+     ports:
+         - exposedPort: 3100
+         - exposedPort: 3130
+         - exposedPort: 13131
+         - exposedPort: 13132
+         - exposedPort: 13133
+     memoryLimit: "512M"
+  initContainers:
+  - name: remote-runtime-injector
+    image: eclipse/che-theia-endpoint-runtime-binary:7.3.3
+    volumes:
+      - mountPath: "/remote-endpoint"
+        name: remote-endpoint
+        ephemeral: true
+    env:
+      - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+        value: /remote-endpoint/plugin-remote-endpoint
+      - name: REMOTE_ENDPOINT_VOLUME_NAME
+        value: remote-endpoint


### PR DESCRIPTION
### What does this PR do?
Add the 7.3.2 and 7.3.3 bugfix version of che-machine-exec and che-theia to master branch to ensure compatibility when updating Che.

Metas are copied from 7.3.3 tag.

Fixes https://github.com/eclipse/che/issues/15444 for future releases.

