### PR TITLE
Setting correct versions of the container runtime images for broadcommfd plugins

### DIFF
--- a/v3/plugins/broadcommfd/cobol-language-support/0.9.1/meta.yaml
+++ b/v3/plugins/broadcommfd/cobol-language-support/0.9.1/meta.yaml
@@ -11,7 +11,7 @@ repository: https://github.com/eclipse/che-che4z-lsp-for-cobol
 category: Language
 spec:
   containers:
-    - image: eclipse/che-remote-plugin-runner-java8:next
+    - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
       memoryLimit: 512Mi
   extensions:
     - https://github.com/eclipse/che-che4z-lsp-for-cobol/releases/download/0.9.1/cobol-language-support-0.9.1.vsix

--- a/v3/plugins/broadcommfd/debugger-for-mainframe/1.0.0/meta.yaml
+++ b/v3/plugins/broadcommfd/debugger-for-mainframe/1.0.0/meta.yaml
@@ -11,7 +11,7 @@ repository: https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mai
 category: Debugger
 spec:
   containers:
-    - image: eclipse/che-remote-plugin-runner-java8:next
+    - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
       memoryLimit: 512Mi
   extensions:
     - https://github.com/eclipse/che-che4z/releases/download/1.1.0/debugger-for-mainframe-1.0.0.vsix


### PR DESCRIPTION
### What does this PR do?

Cherry-pick of the https://github.com/eclipse/che-plugin-registry/pull/327/commits/6295a7130aed666720dc9761f7aa53213dc999b2 

Should be merged to master before we start the 7.7.0 release - https://github.com/eclipse/che/issues/15609

