### PR TITLE
use vscode-kubernetes-tools-1.0.4 instead of...

### DIFF
--- a/v3/plugins/redhat/vscode-camelk/0.0.10/meta.yaml
+++ b/v3/plugins/redhat/vscode-camelk/0.0.10/meta.yaml
@@ -17,4 +17,4 @@ spec:
     memoryLimit: "1G"
   extensions:
   - https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.10-153.vsix
-  - https://github.com/Azure/vscode-kubernetes-tools/releases/download/1.0.0/vscode-kubernetes-tools-1.0.0.vsix
+  - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-kubernetes-tools/vscode-kubernetes-tools-1.0.4.vsix


### PR DESCRIPTION
use vscode-kubernetes-tools-1.0.4 instead of 1.0.0 for consistency with latest
not sure if this change should precipitate creation of a 0.0.10a plugin version

Change-Id: I699c7f23bd194479403719a5d7d6d4fc4bd23cda
Signed-off-by: nickboldt <nboldt@redhat.com>