### PR TITLE
mark vscode-kubernetes-tools-1.0.0...

### DIFF
--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
@@ -10,6 +10,9 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/Azure/vscode-kubernetes-tools
 category: Other
 firstPublicationDate: "2019-05-15"
+deprecate:
+  automigrate: true
+  migrateTo: ms-kubernetes-tools/vscode-kubernetes-tools/latest
 spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.0-58ad4e2"


### PR DESCRIPTION
mark vscode-kubernetes-tools-1.0.0 deprecated in favour of 1.0.4

Change-Id: I589df91ad61d390b86c2851dcaf5c0301c2fb930
Signed-off-by: nickboldt <nboldt@redhat.com>