### PR TITLE
chore(github): Code Owners should match the team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @vparfonov @l0rd @rhopp @skabashnyuk @amisevsk @nickboldt @ibuziuk
+* @ericwill @vinokurig @vitaliy-guliy @benoitf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @ericwill @vinokurig @vitaliy-guliy @benoitf
+* @ericwill @vinokurig @vitaliy-guliy @benoitf @amisevsk @nickboldt


### PR DESCRIPTION
### What does this PR do?

Based on last che SOS and based on repositories scope:

https://docs.google.com/document/d/1h6t4novpcRHjxe8DrEhTamDmit9VviOqcMQNtahM9uE/edit#heading=h.nh4qax6oermn

owners of che-plugin-registry is Eric with plugins team

Change-Id: I286e83ced5a996974095b07e85ff2c5229dd9a26
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

