### PR TITLE
Refactor the template for ConfigMap.

### DIFF
--- a/deploy/kubernetes/che-plugin-registry/templates/configmap.yaml
+++ b/deploy/kubernetes/che-plugin-registry/templates/configmap.yaml
@@ -12,6 +12,14 @@ apiVersion: v1
 metadata:
   name: che-plugin-registry
 data:
-  CHE_SIDECAR_CONTAINERS_REGISTRY_URL: {{ .Values.chePluginSidecarOverride.url }}
-  CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION: {{ .Values.chePluginSidecarOverride.organization }}
-  CHE_SIDECAR_CONTAINERS_REGISTRY_TAG: {{ .Values.chePluginSidecarOverride.tag }}
+{{- with .Values.chePluginSidecarOverride -}}
+  {{- with .url }}
+  CHE_SIDECAR_CONTAINERS_REGISTRY_URL: {{ . }}
+  {{- end }}
+  {{- with .organization }}
+  CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION: {{ . | quote }}
+  {{- end }}
+  {{- with .tag }}
+  CHE_SIDECAR_CONTAINERS_REGISTRY_TAG: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/kubernetes/che-plugin-registry/values.yaml
+++ b/deploy/kubernetes/che-plugin-registry/values.yaml
@@ -13,10 +13,10 @@ chePluginRegistryMemoryLimit: 256Mi
 #chePluginRegistryIngressSecretName: che-tls
 
 # Used to override plugin sidecar image references
-chePluginSidecarOverride:
-  url:
-  organization:
-  tag:
+chePluginSidecarOverride: {}
+#  url:
+#  organization:
+#  tag:
 
 global:
   ingressDomain: 192.168.99.100.nip.io


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Refactors the template for ConfigMap. I have two motivations.

1. Some Helm chart parser (like Argo-CD) reject empty values in `values.yaml`. They recognize empty value as `<nil>` (not `""`)
2. It's better to reduce exported environment variables as possible.
