### PR TITLE
chore(github): Code Owners should match the team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @ericwill @vinokurig @vitaliy-guliy @benoitf @amisevsk @nickboldt
+* @ericwill @vinokurig @vitaliy-guliy @benoitf


### PR DESCRIPTION
### What does this PR do?
To start, owners are the one which are responsible of the repository.
Other committers will be able to merge as well when repository settings will be updated (as discussed in the Eclipse Che calls)

Change-Id: Ia89283f128d1cf39a5b5ec6f295b783a82404deb
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
