### PR TITLE
Secure the che-machine-exec and che-theia plugins

### DIFF
--- a/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
@@ -27,3 +27,5 @@ spec:
      image: "quay.io/eclipse/che-machine-exec:nightly"
      ports:
        - exposedPort: 4444
+     command: ['/go/bin/che-machine-exec', '--static', '/cloud-shell', '--url', '127.0.0.1:4444']
+

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -66,6 +66,8 @@ spec:
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
            value: "3130"
+         - name: THEIA_HOST
+           value: 127.0.0.1
      volumes:
          - mountPath: "/plugins"
            name: plugins


### PR DESCRIPTION
### What does this PR do?

Modify the che-machine-exec and che-theia plugins to only bind to 127.0.0.1.

This is in support eclipse/che#15651 and depends on eclipse/che#15890 and https://github.com/eclipse/che-theia/pull/626 both being merged.