### PR TITLE
Add option to use digests for images referenced in registry

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ REGISTRY="quay.io"
 ORGANIZATION="eclipse"
 TAG="nightly"
 LATEST_ONLY=false
-USE_DIGESTS=true
+USE_DIGESTS=false
 OFFLINE=false
 DOCKERFILE="./build/dockerfiles/Dockerfile"
 
@@ -31,8 +31,8 @@ Options:
         Docker image organization to be used for image; default: 'eclipse'
     --latest-only
         Build registry to only contain 'latest' meta.yamls; default: 'false'
-    --no-digests
-        Build registry to use images pinned by tag instead of by digest
+    --use-digests
+        Build registry to use images pinned by digest instead of tag
     --offline
         Build offline version of registry, with all extension artifacts
         cached in the registry; disabled by default.
@@ -64,8 +64,8 @@ function parse_arguments() {
             LATEST_ONLY=true
             shift
             ;;
-            --no-digests)
-            USE_DIGESTS=false
+            --use-digests)
+            USE_DIGESTS=true
             shift
             ;;
             --offline)

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,7 @@ REGISTRY="quay.io"
 ORGANIZATION="eclipse"
 TAG="nightly"
 LATEST_ONLY=false
+USE_DIGESTS=true
 OFFLINE=false
 DOCKERFILE="./build/dockerfiles/Dockerfile"
 
@@ -30,6 +31,8 @@ Options:
         Docker image organization to be used for image; default: 'eclipse'
     --latest-only
         Build registry to only contain 'latest' meta.yamls; default: 'false'
+    --no-digests
+        Build registry to use images pinned by tag instead of by digest
     --offline
         Build offline version of registry, with all extension artifacts
         cached in the registry; disabled by default.
@@ -61,6 +64,10 @@ function parse_arguments() {
             LATEST_ONLY=true
             shift
             ;;
+            --no-digests)
+            USE_DIGESTS=false
+            shift
+            ;;
             --offline)
             OFFLINE=true
             shift
@@ -86,6 +93,7 @@ if [ "$OFFLINE" = true ]; then
         -t "$IMAGE" \
         -f "$DOCKERFILE" \
         --build-arg LATEST_ONLY="${LATEST_ONLY}" \
+        --build-arg USE_DIGESTS="${USE_DIGESTS}" \
         --target offline-registry .
 else
     echo ""
@@ -93,5 +101,6 @@ else
         -t "$IMAGE" \
         -f "$DOCKERFILE" \
         --build-arg LATEST_ONLY="${LATEST_ONLY}" \
+        --build-arg USE_DIGESTS="${USE_DIGESTS}" \
         --target registry .
 fi

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -12,9 +12,10 @@
 
 # Builder: check meta.yamls and create index.json
 FROM alpine:3.10 AS builder
-RUN apk add --no-cache py-pip jq bash wget && pip install yq jsonschema
+RUN apk add --no-cache py-pip jq bash wget skopeo && pip install yq jsonschema
 
 ARG LATEST_ONLY=false
+ARG USE_DIGESTS=true
 
 COPY ./build/scripts/*.sh ./build/scripts/meta.yaml.schema /build/
 COPY /v3 /build/v3
@@ -28,6 +29,7 @@ RUN ./generate_latest_metas.sh v3 && \
     ./check_plugins_location.sh v3 && \
     ./set_plugin_dates.sh v3 && \
     ./check_metas_schema.sh v3 && \
+    [[ ${USE_DIGESTS} == "true" ]] && ./write_image_digests.sh v3 || \
     ./index.sh v3 > /build/v3/plugins/index.json && \
     ./list_referenced_images.sh v3 > /build/v3/external_images.txt && \
     chmod -R g+rwX /build

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -15,7 +15,7 @@ FROM alpine:3.10 AS builder
 RUN apk add --no-cache py-pip jq bash wget skopeo && pip install yq jsonschema
 
 ARG LATEST_ONLY=false
-ARG USE_DIGESTS=true
+ARG USE_DIGESTS=false
 
 COPY ./build/scripts/*.sh ./build/scripts/meta.yaml.schema /build/
 COPY /v3 /build/v3

--- a/build/dockerfiles/content_sets_centos8_appstream.repo
+++ b/build/dockerfiles/content_sets_centos8_appstream.repo
@@ -1,0 +1,5 @@
+[AppStream]
+name=CentOS-8 - AppStream
+baseurl=http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/
+gpgcheck=0
+enabled=1

--- a/build/dockerfiles/content_sets_epel7.repo
+++ b/build/dockerfiles/content_sets_epel7.repo
@@ -1,5 +1,0 @@
-[epel-7]
-name=epel-7
-baseurl=https://download.fedoraproject.org/pub/epel/7/x86_64/
-enabled=1
-gpgcheck=0

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -32,9 +32,10 @@ METAS_DIR="${METAS_DIR:-${DEFAULT_METAS_DIR}}"
 #   \2 - Registry portion of image, e.g. (quay.io)/eclipse/che-theia:tag
 #   \3 - Organization portion of image, e.g. quay.io/(eclipse)/che-theia:tag
 #   \4 - Image name portion of image, e.g. quay.io/eclipse/(che-theia):tag
-#   \5 - Tag of image, e.g. quay.io/eclipse/che-theia:(tag)
-#   \6 - Optional quotation following image reference
-IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*):([._a-zA-Z0-9-]*)("?)'
+#   \5 - Optional image digest identifier (empty for tags), e.g. quay.io/eclipse/che-theia(@sha256):digest
+#   \6 - Tag of image or digest, e.g. quay.io/eclipse/che-theia:(tag)
+#   \7 - Optional quotation following image reference
+IMAGE_REGEX='([[:space:]]*"?)([._:a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)/([._a-zA-Z0-9-]*)(@sha256)?:([._a-zA-Z0-9-]*)("?)'
 
 # We can't use the `-d` option for readarray because
 # registry.centos.org/centos/httpd-24-centos7 ships with Bash 4.2
@@ -46,15 +47,15 @@ for meta in "${metas[@]}"; do
   # Defaults don't work because registry and tags may be different.
   if [ -n "$REGISTRY" ]; then
     echo "    Updating image registry to $REGISTRY"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4:\5\6|" "$meta"
+    sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$meta"
   fi
   if [ -n "$ORGANIZATION" ]; then
     echo "    Updating image organization to $ORGANIZATION"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4:\5\6|" "$meta"
+    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$meta"
   fi
   if [ -n "$TAG" ]; then
     echo "    Updating image tag to $TAG"
-    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\6|" "$meta"
+    sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$meta"
   fi
 done
 

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -21,6 +21,7 @@ USER 0
 
 ARG BOOTSTRAP=false
 ARG LATEST_ONLY=false
+ARG USE_DIGESTS=true
 
 # to get all the python deps pre-fetched so we can build in Brew:
 # 1. extract files in the container to your local filesystem
@@ -37,7 +38,7 @@ ARG LATEST_ONLY=false
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io or registry.access.redhat.com
 # enable rhel 7 or 8 content sets (from Brew) to resolve jq as rpm
-COPY ./build/dockerfiles/content_sets_epel7.repo /etc/yum.repos.d/
+COPY ./build/dockerfiles/content_sets_centos8_appstream.repo /etc/yum.repos.d/
 
 COPY ./build/dockerfiles/rhel.install.sh /tmp
 RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
@@ -59,6 +60,7 @@ RUN ./generate_latest_metas.sh v3 && \
     ./check_plugins_location.sh v3 && \
     ./set_plugin_dates.sh v3 && \
     ./check_metas_schema.sh v3 && \
+    [[ ${USE_DIGESTS} == "true" ]] && ./write_image_digests.sh v3 || \
     ./index.sh v3 > /build/v3/plugins/index.json && \
     ./list_referenced_images.sh v3 > /build/v3/external_images.txt && \
     chmod -R g+rwX /build

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -21,7 +21,7 @@ USER 0
 
 ARG BOOTSTRAP=false
 ARG LATEST_ONLY=false
-ARG USE_DIGESTS=true
+ARG USE_DIGESTS=false
 
 # to get all the python deps pre-fetched so we can build in Brew:
 # 1. extract files in the container to your local filesystem

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -23,6 +23,10 @@ ARG BOOTSTRAP=false
 ARG LATEST_ONLY=false
 ARG USE_DIGESTS=false
 
+ENV BOOTSTRAP=${BOOTSTRAP} \
+    LATEST_ONLY=${LATEST_ONLY} \
+    USE_DIGESTS=${USE_DIGESTS}
+
 # to get all the python deps pre-fetched so we can build in Brew:
 # 1. extract files in the container to your local filesystem
 #    find v3 -type f -exec dos2unix {} \;

--- a/build/dockerfiles/rhel.entrypoint.sh
+++ b/build/dockerfiles/rhel.entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/rhel.install.sh
+++ b/build/dockerfiles/rhel.install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/dockerfiles/rhel.install.sh
+++ b/build/dockerfiles/rhel.install.sh
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-microdnf install -y findutils bash wget yum gzip tar jq python3-six python3-pip && microdnf -y clean all && \
+microdnf install -y findutils bash wget yum gzip tar jq python3-six python3-pip skopeo && microdnf -y clean all && \
 # install yq (depends on jq and pyyaml - if jq and pyyaml not already installed, this will try to compile it)
 if [[ -f /tmp/root-local.tgz ]] || [[ ${BOOTSTRAP} == "true" ]]; then \
     mkdir -p /root/.local; tar xf /tmp/root-local.tgz -C /root/.local/; rm -fr /tmp/root-local.tgz;  \

--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+
+readarray -d '' metas < <(find "$1" -name 'meta.yaml' -print0)
+for image in $(yq -r '.spec | .containers[]?,.initContainers[]? | .image' "${metas[@]}" | sort | uniq); do
+  echo "Rewriting image $image"
+  digest=$(skopeo inspect "docker://${image}" | jq -r '.Digest')
+  echo "  to use digest $digest"
+  digest_image="${image%:*}@${digest}"
+
+  # Rewrite images to use sha-256 digests
+  sed -i -E 's|"?'"${image}"'"?|"'"${digest_image}"'" # tag: '"${image}"'|g' "${metas[@]}"
+done

--- a/cico_build_ci.sh
+++ b/cico_build_ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/cico_build_nightly.sh
+++ b/cico_build_nightly.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/cico_build_release.sh
+++ b/cico_build_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/deploy/kubernetes/che-plugin-registry/Chart.yaml
+++ b/deploy/kubernetes/che-plugin-registry/Chart.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/deploy/kubernetes/che-plugin-registry/templates/configmap.yaml
+++ b/deploy/kubernetes/che-plugin-registry/templates/configmap.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/deploy/kubernetes/che-plugin-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/che-plugin-registry/templates/deployment.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/deploy/kubernetes/che-plugin-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/che-plugin-registry/templates/ingress.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/deploy/kubernetes/che-plugin-registry/templates/service.yaml
+++ b/deploy/kubernetes/che-plugin-registry/templates/service.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/deploy/kubernetes/che-plugin-registry/values.yaml
+++ b/deploy/kubernetes/che-plugin-registry/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/deploy/openshift/che-plugin-registry.yml
+++ b/deploy/openshift/che-plugin-registry.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
### What does this PR do?
Add script /build/scripts/write_image_digests.sh, which will rewrite all image references in registry to use the current digest for each image tag. E.g.
```
  containers:
    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
```
is replaced with
```
  containers:
    - image: "quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d" # tag: quay.io/eclipse/che-sidecar-java:8-0cfbacb
```
To enable this functionality, it is necessary to install `skopeo` in the builder images, which required changing adding the CentOS8-AppStream repo for the rhel build.

### Additional info
Digest-rewriting functionality is disabled by default and can be enabled by using the `./build.sh` option `--use-digests`, or by passing docker build arg `USE_DIGESTS=true`. 

Existing airgap options are unaffected (you can still set env vars to override registry, organization, and tag). In the case of overriding tags, image digests are replaced with the tag specified.

There's also a commit included to update all copyright years for 2020.

### Testing
Image is available as `amisevsk/che-plugin-registry:digests`. I've tested the changes on the dev cluster and locally.