### PR TITLE
Revert "Modify the che-machine-exec and che-theia plugins to only bind to 127.0.0.1. (#378)"

### DIFF
--- a/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
@@ -27,5 +27,3 @@ spec:
      image: "quay.io/eclipse/che-machine-exec:nightly"
      ports:
        - exposedPort: 4444
-     command: ['/go/bin/che-machine-exec', '--static', '/cloud-shell', '--url', '127.0.0.1:4444']
-

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -66,8 +66,6 @@ spec:
            value: 0.0.0.0
          - name: HOSTED_PLUGIN_PORT
            value: "3130"
-         - name: THEIA_HOST
-           value: 127.0.0.1
      volumes:
          - mountPath: "/plugins"
            name: plugins


### PR DESCRIPTION
### What does this PR do?
Revert "Modify the che-machine-exec and che-theia plugins to only bind to 127.0.0.1. (#378)"
This reverts commit 35e2f3c9a8d8ceeb75b13ebf3c3d8a17be5427ba.

Tested on 
# Single user minikube
<img width="1670" alt="Знімок екрана 2020-02-19 о 14 51 01" src="https://user-images.githubusercontent.com/1614429/74845925-f9ef4f80-532f-11ea-86ac-989df621387f.png">

# Multiuser minikube
<img width="1010" alt="Знімок екрана 2020-02-19 о 15 11 32" src="https://user-images.githubusercontent.com/1614429/74845936-fc51a980-532f-11ea-9fa0-2eb3bd5b24c3.png">

# Multiuser crc
![Знімок екрана 2020-02-19 о 15 43 34](https://user-images.githubusercontent.com/1614429/74845944-ffe53080-532f-11ea-94c6-2d4e46f53d66.png)




Related to https://github.com/eclipse/che/issues/16053