### PR TITLE
Add node-debug VS Code extensions to Che Typescript plugin

### DIFF
--- a/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
@@ -17,3 +17,5 @@ spec:
     memoryLimit: '512Mi'
   extensions:
   - https://download.jboss.org/jbosstools/vscode/3rdparty/ms-code.typescript/che-typescript-language-1.35.1.vsix
+  - https://github.com/theia-ide/vscode-node-debug/releases/download/v1.35.3/node-debug-1.35.3.vsix
+  - https://github.com/theia-ide/vscode-node-debug2/releases/download/v1.33.0/node-debug2-1.33.0.vsix


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

### What does this PR do?

Adds VS Code node-debug extensions to Che Typescript plugin as `@theia/debug-nodejs` Theia extension is removed in upstream Theia.

Devfile to check
```
metadata:
  name: pr-che_theia-643-t1v9q
attributes:
  persistVolumes: 'false'
components:
  - type: cheEditor
    reference: >-
      https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-643/simple/che-theia-editor.yaml
  - type: chePlugin
    reference: >-
      https://raw.githubusercontent.com/eclipse/che-plugin-registry/8abc243e3392b6181eb8914ca1c7705c15cec3e5/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
apiVersion: 1.0.0

```
