### PR TITLE
Don't rewrite image digests for images we can't read

### DIFF
--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -8,14 +8,29 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+LOG_FILE="/tmp/image_digests.log"
+
+function handle_error() {
+  echo "  Could not read image metadata through skopeo inspect; skipping"
+  echo -n "  Reason: "
+  sed 's|^|    |g' $LOG_FILE
+}
 
 readarray -d '' metas < <(find "$1" -name 'meta.yaml' -print0)
 for image in $(yq -r '.spec | .containers[]?,.initContainers[]? | .image' "${metas[@]}" | sort | uniq); do
   echo "Rewriting image $image"
-  digest=$(skopeo inspect "docker://${image}" | jq -r '.Digest')
+  # Need to look before we leap in case image is not accessible
+  if ! image_data=$(skopeo inspect "docker://${image}" 2>"$LOG_FILE"); then
+    handle_error
+    continue
+  fi
+  # Grab digest from image metadata json
+  digest=$(echo "$image_data" | jq -r '.Digest')
+
   echo "  to use digest $digest"
   digest_image="${image%:*}@${digest}"
 
   # Rewrite images to use sha-256 digests
   sed -i -E 's|"?'"${image}"'"?|"'"${digest_image}"'" # tag: '"${image}"'|g' "${metas[@]}"
 done
+rm $LOG_FILE


### PR DESCRIPTION
### What does this PR do?
Don't overwrite image references with nonsense when we can't access the image being used.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/16281