### PR TITLE
Use PNG icons for Kubernetes plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ type:                  # plugin type; e.g. "Theia plugin", "Che Editor"
 displayName:           # name shown in user dashboard
 title:                 # plugin title
 description:           # short description of plugin's purpose
-icon:                  # link to SVG icon
+icon:                  # link to SVG or PNG icon
 repository:            # URL for plugin (e.g. Github repo)
 category:              # see [1]
 firstPublicationDate:  # optional; see [2]

--- a/build/scripts/meta.yaml.schema
+++ b/build/scripts/meta.yaml.schema
@@ -34,7 +34,7 @@
     },
     "icon": {
       "type": "string",
-      "pattern": "[-._a-zA-Z0-9]+(.svg|.png)[^.]*$"
+      "pattern": "[-._a-zA-Z0-9]+?\\.(?:svg|png)(?:\\?.*)?$"
     },
     "description": {
       "type": "string"

--- a/build/scripts/meta.yaml.schema
+++ b/build/scripts/meta.yaml.schema
@@ -34,7 +34,7 @@
     },
     "icon": {
       "type": "string",
-      "pattern": "[-._a-zA-Z0-9]+.svg[^.]*$"
+      "pattern": "[-._a-zA-Z0-9]+(.svg|.png)[^.]*$"
     },
     "description": {
       "type": "string"

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/0.1.17/meta.yaml
@@ -6,7 +6,7 @@ type: VS Code extension
 displayName: Kubernetes
 title: Kubernetes Tools
 description: Develop, deploy and debug Kubernetes applications
-icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+icon: https://raw.githubusercontent.com/Azure/vscode-kubernetes-tools/0.1.17/images/k8s-logo.png
 repository: https://github.com/Azure/vscode-kubernetes-tools
 category: Other
 firstPublicationDate: "2019-03-11"

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.0/meta.yaml
@@ -6,7 +6,7 @@ type: VS Code extension
 displayName: Kubernetes
 title: Kubernetes Tools
 description: Develop, deploy and debug Kubernetes applications
-icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+icon: https://raw.githubusercontent.com/Azure/vscode-kubernetes-tools/1.0.0/images/k8s-logo.png
 repository: https://github.com/Azure/vscode-kubernetes-tools
 category: Other
 firstPublicationDate: "2019-05-15"

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.4/meta.yaml
@@ -6,7 +6,7 @@ type: VS Code extension
 displayName: Kubernetes
 title: Kubernetes Tools
 description: Develop, deploy and debug Kubernetes applications
-icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+icon: https://raw.githubusercontent.com/Azure/vscode-kubernetes-tools/1.0.4/images/k8s-logo.png
 repository: https://github.com/Azure/vscode-kubernetes-tools
 category: Other
 firstPublicationDate: "2019-10-16"

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.9/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.0.9/meta.yaml
@@ -6,7 +6,7 @@ type: VS Code extension
 displayName: Kubernetes
 title: Kubernetes Tools
 description: Develop, deploy and debug Kubernetes applications
-icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+icon: https://raw.githubusercontent.com/Azure/vscode-kubernetes-tools/1.0.9/images/k8s-logo.png
 repository: https://github.com/Azure/vscode-kubernetes-tools
 category: Other
 firstPublicationDate: "2020-01-14"


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

### What does this PR do?

- Allows to use PNG images for plugins
- Sets proper images for Kubernetes plugin

Solves issue https://github.com/eclipse/che/issues/14502