### PR TITLE
Replace CHE with Che in machine exec descriptions

### DIFF
--- a/v3/plugins/eclipse/che-machine-exec-plugin/0.0.1/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/0.0.1/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace machines.
+  or tasks for Eclipse Che workspace machines.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-02-05"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.0.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.0.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-02-05"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.1.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.1.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-02-05"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.2.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.2.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-09-27"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.3.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.3.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-10-16"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.3.1/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.3.1/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-10-28"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.3.2/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.3.2/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-11-14"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.3.3/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.3.3/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-12-04"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.4.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.4.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-11-06"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.5.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.5.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-11-27"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.5.1/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.5.1/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-12-02"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.6.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.6.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-12-18"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.7.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.7.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-01-08"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.7.1/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.7.1/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-01-17"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.8.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.8.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-01-29"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.9.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.9.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-02-18"

--- a/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
@@ -6,7 +6,7 @@ type: Che Plugin
 displayName: Che machine-exec Service
 title: Che machine-exec Service Plugin
 description: Che Plug-in with che-machine-exec service to provide creation terminal
-  or tasks for Eclipse CHE workspace containers.
+  or tasks for Eclipse Che workspace containers.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2019-11-07"


### PR DESCRIPTION
### What does this PR do?
`s/CHE/Che/` to clean up the workspace startup log.