### PR TITLE
Validate meta.yaml versions to be strings, not numbers

### DIFF
--- a/build/scripts/meta.yaml.schema
+++ b/build/scripts/meta.yaml.schema
@@ -17,9 +17,8 @@
       "pattern": "^[-._a-zA-Z0-9]+$"
     },
     "version": {
-      "type": ["number", "string"],
-      "pattern": "^[-._a-zA-Z0-9]+$",
-      "minimum": 0
+      "type": ["string"],
+      "pattern": "^[-._a-zA-Z0-9]+$"
     },
     "type": {
       "type": "string",

--- a/build/scripts/util.sh
+++ b/build/scripts/util.sh
@@ -15,8 +15,8 @@
 function evaluate_plugin_id() {
     # yq command to do the same; not used as it is much slower.
     # yq -r '"\(.publisher)/\(.name)/\(.version)"' $1
-    name_field=$(sed -nr 's|^name: ([-.0-9A-Za-z]+)|\1|p' "$1")
-    version_field=$(sed -nr 's|^version: ([-.0-9A-Za-z]+)|\1|p' "$1")
-    publisher_field=$(sed -nr 's|^publisher: ([-.0-9A-Za-z]+)|\1|p' "$1")
+    name_field=$(sed -nr 's|^name: "?([-.0-9A-Za-z]+)"?|\1|p' "$1")
+    version_field=$(sed -nr 's|^version: "?([-.0-9A-Za-z]+)"?|\1|p' "$1")
+    publisher_field=$(sed -nr 's|^publisher: "?([-.0-9A-Za-z]+)"?|\1|p' "$1")
     echo "${publisher_field}/${name_field}/${version_field}"
 }

--- a/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
+++ b/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 publisher: che-incubator
 name: cpptools
-version: 0.1
+version: "0.1"
 type: VS Code extension
 displayName: C/C++ tools
 title: C/C++ intelliSense, debugging and code browsing


### PR DESCRIPTION
### What does this PR do?
Changes the validation performed on meta.yaml version numbers to only accept string values. Accepting number and string as types at the same time can cause subtle issues due to how json parsing works: if a value can be interpreted as a number, it will be; otherwise it is a string. This means: 
- Version `3.2.1` will parse as a string, `3.2` will parse as a number
- Git commit short hashes can *occasionally* be exclusively digits, which results in parsing as a number, e.g. https://github.com/eclipse/che-plugin-registry/commit/946650187395af0a5e13eb91e4b743a3f25a59bb. 

This can trip up implementations that assume they're getting a version string. 

From a design perspective, versions should never be specified as a number, as standard number logic does not apply to versions (1.10 is after 1.9, for example)

### What issue does it address?
The changes in this PR would make the underlying issue in https://github.com/eclipse/che/issues/16340 clear by running `./build/scripts/check_metas_schema.sh`