### PR TITLE
CRW-653 support optional extra processing to check backup registries

### DIFF
--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -25,7 +25,8 @@ for image in $(yq -r '.spec | .containers[]?,.initContainers[]? | .image' "${met
   else 
     # for other build methods or for falling back to other registries when not found, can apply transforms here
     if [[ -x "$(dirname "$0")/write_image_digests_alternate_urls.sh" ]]; then
-      # shellcheck source=./build/scripts/util.sh
+      # since extension file may not exist, disable this check
+      # shellcheck disable=SC1091
       source "$(dirname "$0")/write_image_digests_alternate_urls.sh"
     fi
   fi

--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -11,23 +11,31 @@
 LOG_FILE="/tmp/image_digests.log"
 
 function handle_error() {
-  echo "  Could not read image metadata through skopeo inspect; skipping"
+  the_image="$1"
+  echo "  Could not read image metadata through skopeo inspect; skip $the_image"
   echo -n "  Reason: "
   sed 's|^|    |g' $LOG_FILE
 }
 
 readarray -d '' metas < <(find "$1" -name 'meta.yaml' -print0)
 for image in $(yq -r '.spec | .containers[]?,.initContainers[]? | .image' "${metas[@]}" | sort | uniq); do
-  echo "Rewriting image $image"
-  # Need to look before we leap in case image is not accessible
-  if ! image_data=$(skopeo inspect "docker://${image}" 2>"$LOG_FILE"); then
-    handle_error
+  digest="$(skopeo inspect "docker://${image}" 2>"$LOG_FILE" | jq -r '.Digest')"
+  if [[ ${digest} ]]; then
+    echo "    $digest # ${image}"
+  else 
+    # for other build methods or for falling back to other registries when not found, can apply transforms here
+    if [[ -x "$(dirname "$0")/write_image_digests_alternate_urls.sh" ]]; then
+      # shellcheck source=./build/scripts/util.sh
+      source "$(dirname "$0")/write_image_digests_alternate_urls.sh"
+    fi
+  fi
+
+  # don't rewrite if we couldn't get a digest from either the basic image or the alternative image
+  if [[ ! ${digest} ]]; then
+    handle_error "$image"
     continue
   fi
-  # Grab digest from image metadata json
-  digest=$(echo "$image_data" | jq -r '.Digest')
 
-  echo "  to use digest $digest"
   digest_image="${image%:*}@${digest}"
 
   # Rewrite images to use sha-256 digests

--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -26,7 +26,7 @@ for image in $(yq -r '.spec | .containers[]?,.initContainers[]? | .image' "${met
     # for other build methods or for falling back to other registries when not found, can apply transforms here
     if [[ -x "$(dirname "$0")/write_image_digests_alternate_urls.sh" ]]; then
       # since extension file may not exist, disable this check
-      # shellcheck disable=SC1091
+      # shellcheck disable=SC1090,SC1091
       source "$(dirname "$0")/write_image_digests_alternate_urls.sh"
     fi
   fi

--- a/build/scripts/write_image_digests.sh
+++ b/build/scripts/write_image_digests.sh
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 LOG_FILE="/tmp/image_digests.log"
 
 function handle_error() {
@@ -24,10 +25,10 @@ for image in $(yq -r '.spec | .containers[]?,.initContainers[]? | .image' "${met
     echo "    $digest # ${image}"
   else 
     # for other build methods or for falling back to other registries when not found, can apply transforms here
-    if [[ -x "$(dirname "$0")/write_image_digests_alternate_urls.sh" ]]; then
+    if [[ -x "${SCRIPT_DIR}/write_image_digests_alternate_urls.sh" ]]; then
       # since extension file may not exist, disable this check
-      # shellcheck disable=SC1090,SC1091
-      source "$(dirname "$0")/write_image_digests_alternate_urls.sh"
+      # shellcheck disable=SC1090
+      source "${SCRIPT_DIR}/write_image_digests_alternate_urls.sh"
     fi
   fi
 


### PR DESCRIPTION
CRW-653 support optional extra processing to check backup registries; tweak console output to report digest and source image if successful, and which image failed if skipping

Change-Id: Ieee4cca1344b2dd4f86c10b9e4ceae2eb02dcdd8
Signed-off-by: nickboldt <nboldt@redhat.com>