### PR TITLE
Adding 7.9.1 and 7.9.2 version of che-theia and machine-exec plugins

### DIFF
--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.9.1/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.9.1/meta.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+publisher: eclipse
+name: che-machine-exec-plugin
+version: 7.9.1
+type: Che Plugin
+displayName: Che machine-exec Service
+title: Che machine-exec Service Plugin
+description: Che Plug-in with che-machine-exec service to provide creation terminal
+  or tasks for Eclipse CHE workspace containers.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2020-03-04"
+category: Other
+spec:
+  endpoints:
+   -  name: "che-machine-exec"
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: ws
+        type: terminal
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+   - name: che-machine-exec
+     image: "quay.io/eclipse/che-machine-exec:7.9.1"
+     ports:
+       - exposedPort: 4444
+     command: ['/go/bin/che-machine-exec', '--static', '/cloud-shell', '--url', '127.0.0.1:4444']

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.9.2/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.9.2/meta.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+publisher: eclipse
+name: che-machine-exec-plugin
+version: 7.9.2
+type: Che Plugin
+displayName: Che machine-exec Service
+title: Che machine-exec Service Plugin
+description: Che Plug-in with che-machine-exec service to provide creation terminal
+  or tasks for Eclipse CHE workspace containers.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2020-03-18"
+category: Other
+spec:
+  endpoints:
+   -  name: "che-machine-exec"
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: ws
+        type: terminal
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+   - name: che-machine-exec
+     image: "quay.io/eclipse/che-machine-exec:7.9.2"
+     ports:
+       - exposedPort: 4444
+     command: ['/go/bin/che-machine-exec', '--static', '/cloud-shell', '--url', '127.0.0.1:4444']

--- a/v3/plugins/eclipse/che-theia/7.9.1/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.9.1/meta.yaml
@@ -1,0 +1,93 @@
+apiVersion: v2
+publisher: eclipse
+name: che-theia
+version: 7.9.1
+type: Che Editor
+displayName: theia-ide
+title: Eclipse Theia
+description: Eclipse Theia
+icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
+category: Editor
+repository: https://github.com/eclipse/che-theia
+firstPublicationDate: "2020-03-04"
+spec:
+  endpoints:
+   -  name: "theia"
+      public: true
+      targetPort: 3100
+      attributes:
+        protocol: http
+        type: ide
+        secure: true
+        cookiesAuthEnabled: true
+        discoverable: false
+   -  name: "webviews"
+      public: true
+      targetPort: 3100
+      attributes:
+        protocol: http
+        type: webview
+        secure: true
+        cookiesAuthEnabled: true
+        discoverable: false
+        unique: true
+   -  name: "theia-dev"
+      public: true
+      targetPort: 3130
+      attributes:
+        protocol: http
+        type: ide-dev
+        discoverable: false
+   -  name: "theia-redirect-1"
+      public: true
+      targetPort: 13131
+      attributes:
+        protocol: http
+        discoverable: false
+   -  name: "theia-redirect-2"
+      public: true
+      targetPort: 13132
+      attributes:
+        protocol: http
+        discoverable: false
+   -  name: "theia-redirect-3"
+      public: true
+      targetPort: 13133
+      attributes:
+        protocol: http
+        discoverable: false
+  containers:
+   - name: theia-ide
+     image: "quay.io/eclipse/che-theia:7.9.1"
+     env:
+         - name: THEIA_PLUGINS
+           value: local-dir:///plugins
+         - name: HOSTED_PLUGIN_HOSTNAME
+           value: 0.0.0.0
+         - name: HOSTED_PLUGIN_PORT
+           value: "3130"
+         - name: THEIA_HOST
+           value: 127.0.0.1
+     volumes:
+         - mountPath: "/plugins"
+           name: plugins
+     mountSources: true
+     ports:
+         - exposedPort: 3100
+         - exposedPort: 3130
+         - exposedPort: 13131
+         - exposedPort: 13132
+         - exposedPort: 13133
+     memoryLimit: "512M"
+  initContainers:
+  - name: remote-runtime-injector
+    image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.9.1"
+    volumes:
+      - mountPath: "/remote-endpoint"
+        name: remote-endpoint
+        ephemeral: true
+    env:
+      - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+        value: /remote-endpoint/plugin-remote-endpoint
+      - name: REMOTE_ENDPOINT_VOLUME_NAME
+        value: remote-endpoint

--- a/v3/plugins/eclipse/che-theia/7.9.2/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.9.2/meta.yaml
@@ -1,0 +1,93 @@
+apiVersion: v2
+publisher: eclipse
+name: che-theia
+version: 7.9.2
+type: Che Editor
+displayName: theia-ide
+title: Eclipse Theia
+description: Eclipse Theia
+icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
+category: Editor
+repository: https://github.com/eclipse/che-theia
+firstPublicationDate: "2020-03-18"
+spec:
+  endpoints:
+   -  name: "theia"
+      public: true
+      targetPort: 3100
+      attributes:
+        protocol: http
+        type: ide
+        secure: true
+        cookiesAuthEnabled: true
+        discoverable: false
+   -  name: "webviews"
+      public: true
+      targetPort: 3100
+      attributes:
+        protocol: http
+        type: webview
+        secure: true
+        cookiesAuthEnabled: true
+        discoverable: false
+        unique: true
+   -  name: "theia-dev"
+      public: true
+      targetPort: 3130
+      attributes:
+        protocol: http
+        type: ide-dev
+        discoverable: false
+   -  name: "theia-redirect-1"
+      public: true
+      targetPort: 13131
+      attributes:
+        protocol: http
+        discoverable: false
+   -  name: "theia-redirect-2"
+      public: true
+      targetPort: 13132
+      attributes:
+        protocol: http
+        discoverable: false
+   -  name: "theia-redirect-3"
+      public: true
+      targetPort: 13133
+      attributes:
+        protocol: http
+        discoverable: false
+  containers:
+   - name: theia-ide
+     image: "quay.io/eclipse/che-theia:7.9.2"
+     env:
+         - name: THEIA_PLUGINS
+           value: local-dir:///plugins
+         - name: HOSTED_PLUGIN_HOSTNAME
+           value: 0.0.0.0
+         - name: HOSTED_PLUGIN_PORT
+           value: "3130"
+         - name: THEIA_HOST
+           value: 127.0.0.1
+     volumes:
+         - mountPath: "/plugins"
+           name: plugins
+     mountSources: true
+     ports:
+         - exposedPort: 3100
+         - exposedPort: 3130
+         - exposedPort: 13131
+         - exposedPort: 13132
+         - exposedPort: 13133
+     memoryLimit: "512M"
+  initContainers:
+  - name: remote-runtime-injector
+    image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.9.2"
+    volumes:
+      - mountPath: "/remote-endpoint"
+        name: remote-endpoint
+        ephemeral: true
+    env:
+      - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+        value: /remote-endpoint/plugin-remote-endpoint
+      - name: REMOTE_ENDPOINT_VOLUME_NAME
+        value: remote-endpoint


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?

7.10.x branch is missing `7.9.1` and `7.9.2` versions of che-theia and machine-exec plugins which are required for backward compatibility