### PR TITLE
Update references to docker images

### DIFF
--- a/v3/plugins/broadcommfd/cobol-language-support/0.10.1/meta.yaml
+++ b/v3/plugins/broadcommfd/cobol-language-support/0.10.1/meta.yaml
@@ -11,7 +11,8 @@ repository: https://github.com/eclipse/che-che4z-lsp-for-cobol
 category: Language
 spec:
   containers:
-    - image: quay.io/eclipse/che-sidecar-java:11-f76ca45
+    # - image: quay.io/eclipse/che-sidecar-java:11-f76ca45
+    - image: quay.io/eclipse/che-sidecar-java@sha256:54a5f721588455403d8c2a81d1fbc8fef2c6a32aead44f2fb3e24a8a1fddb9a2
       memoryLimit: 1Gi
   extensions:
     - https://github.com/eclipse/che-che4z-lsp-for-cobol/releases/download/0.10.1/cobol-language-support-0.10.1.vsix

--- a/v3/plugins/broadcommfd/debugger-for-mainframe/1.0.2/meta.yaml
+++ b/v3/plugins/broadcommfd/debugger-for-mainframe/1.0.2/meta.yaml
@@ -11,7 +11,8 @@ repository: https://github.com/BroadcomMFD/debugger-for-mainframe
 category: Debugger
 spec:
   containers:
-    - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
       memoryLimit: 512Mi
   extensions:
     - https://github.com/BroadcomMFD/debugger-for-mainframe/releases/download/1.0.2/debugger-for-mainframe-1.0.2.vsix

--- a/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
+++ b/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml
@@ -15,8 +15,9 @@ deprecate:
   migrateTo: redhat/vscode-apache-camel/latest
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
+    # - image: quay.io/eclipse/che-sidecar-java:11-f76ca45
+    - image: quay.io/eclipse/che-sidecar-java@sha256:54a5f721588455403d8c2a81d1fbc8fef2c6a32aead44f2fb3e24a8a1fddb9a2
       name: vscode-apache-camel
-      memoryLimit: "512Mi"
+      memoryLimit: 512Mi
   extensions:
     - https://github.com/camel-tooling/camel-lsp-client-vscode/releases/download/0.0.14/camel-tooling.vscode-apache-camel-0.0.14.vsix

--- a/v3/plugins/cdr/code-server/2.1650-vsc1.39.2/meta.yaml
+++ b/v3/plugins/cdr/code-server/2.1650-vsc1.39.2/meta.yaml
@@ -20,11 +20,12 @@ spec:
         type: ide
   containers:
    - name: code-server
-     image: "docker.io/chinodesuuu/coder:2.1650-vsc1.39.2-che"
+    #  image: docker.io/chinodesuuu/coder:2.1650-vsc1.39.2-che
+     image: docker.io/chinodesuuu/coder@sha256:1af9c45c3f8c9836dba10c4a2c7b43915bc04fa4b9b9cc598d4bad5cf036817e
      mountSources: true
      ports:
          - exposedPort: 9000
-     memoryLimit: "1024M" 
+     memoryLimit: 1024M
      volumes:
         - mountPath: '/home/coder/.local/share/code-server'
           name: 'user-data'

--- a/v3/plugins/cdr/code-server/next/meta.yaml
+++ b/v3/plugins/cdr/code-server/next/meta.yaml
@@ -20,11 +20,12 @@ spec:
         type: ide
   containers:
    - name: code-server
-     image: "docker.io/chinodesuuu/coder:next"
+    #  image: docker.io/chinodesuuu/coder:next
+     image: docker.io/chinodesuuu/coder@sha256:77f51200f6f9ff62551794be48a3497e464c93f2420877253b98de3e041e0e9d
      mountSources: true
      ports:
          - exposedPort: 9000
-     memoryLimit: "1024M" 
+     memoryLimit: 1024M 
      volumes:
         - mountPath: '/home/coder/.local/share/code-server'
           name: 'user-data'

--- a/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
+++ b/v3/plugins/che-incubator/cpptools/0.1/meta.yaml
@@ -12,9 +12,10 @@ category: Language
 firstPublicationDate: '2019-08-06'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-clang:8-83adb3a"
+    # - image: quay.io/eclipse/che-sidecar-clang:8-83adb3a
+    - image: quay.io/eclipse/che-sidecar-clang@sha256:1c217f34ca69108fdd1ab844c0bcf960edff92519677bde4f8a5f4841b104745
       name: cpp-plugins
-      memoryLimit: '512Mi'
+      memoryLimit: 512Mi
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-gdb-vscode/cdt-gdb-vscode-0.0.90-ba3a21.vsix
     - https://download.jboss.org/jbosstools/vscode/3rdparty/cdt-vscode/cdt-vscode-0.0.7-75cf95.vsix

--- a/v3/plugins/che-incubator/theia-dev/0.0.1/meta.yaml
+++ b/v3/plugins/che-incubator/theia-dev/0.0.1/meta.yaml
@@ -19,7 +19,8 @@ spec:
       protocol: http
   containers:
    - name: theia-dev
-     image: "quay.io/eclipse/che-theia-dev:next"
+    #  image: quay.io/eclipse/che-theia-dev:next
+     image: quay.io/eclipse/che-theia-dev@sha256:e44091f25b6a33a852431b6e5ae5f44b7e21b8c8f1182509854fdca03e081839
      commands:
        - name: uname
          workingDir: "$(project)"
@@ -27,4 +28,4 @@ spec:
      mountSources: true
      ports:
        - exposedPort: 3010
-     memoryLimit: "2Gi"
+     memoryLimit: 2Gi

--- a/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
+++ b/v3/plugins/che-incubator/typescript/1.35.1/meta.yaml
@@ -12,8 +12,9 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
+  # - image: quay.io/eclipse/che-sidecar-node:10-0cb5d78
+  - image: quay.io/eclipse/che-sidecar-node@sha256:0370b2c3d52d31c9fd52bff3edb84bd36bbcc2aff6224957d6dd94935843ee59
     name: vscode-typescript
-    memoryLimit: '512Mi'
+    memoryLimit: 512Mi
   extensions:
   - https://download.jboss.org/jbosstools/vscode/3rdparty/ms-code.typescript/che-typescript-language-1.35.1.vsix

--- a/v3/plugins/dirigiblelabs/dirigible/3.4.0/meta.yaml
+++ b/v3/plugins/dirigiblelabs/dirigible/3.4.0/meta.yaml
@@ -20,7 +20,8 @@ spec:
         type: ide
   containers:
    - name: eclipse-dirigible
-     image: "docker.io/dirigiblelabs/dirigible-openshift:3.4.0"
+    #  image: docker.io/dirigiblelabs/dirigible-openshift:3.4.0
+     image: docker.io/dirigiblelabs/dirigible-openshift@sha256:3365635d1e0403697dea0674bbbdc749c4be2db29818a93b8e1e53c3c5144113
      env:
          - name: DIRIGIBLE_DATABASE_PROVIDER
            value: "local"
@@ -45,4 +46,4 @@ spec:
      mountSources: true
      ports:
          - exposedPort: 8080
-     memoryLimit: "1024M"
+     memoryLimit: 1024M

--- a/v3/plugins/eclipse/che-machine-exec-plugin/7.11.0/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/7.11.0/meta.yaml
@@ -24,7 +24,8 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: che-machine-exec
-     image: "quay.io/eclipse/che-machine-exec:7.11.0"
+    #  image: quay.io/eclipse/che-machine-exec:7.11.0
+     image: quay.io/eclipse/che-machine-exec@sha256:62b65767780978f937f433f4be6f5ae7dc394d70f9df8b4302e48df8bbae3a07
      ports:
        - exposedPort: 4444
      command: ['/go/bin/che-machine-exec', '--static', '/cloud-shell', '--url', '127.0.0.1:4444']

--- a/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
@@ -24,7 +24,8 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: che-machine-exec
-     image: "quay.io/eclipse/che-machine-exec:nightly"
+    #  image: quay.io/eclipse/che-machine-exec:nightly
+     image: quay.io/eclipse/che-machine-exec@sha256:df43419720820ec85df556ae89135b6f42b93869a0b72dc36b80564eb0e785cc
      ports:
        - exposedPort: 4444
      command: ['/go/bin/che-machine-exec', '--static', '/cloud-shell', '--url', '127.0.0.1:4444']

--- a/v3/plugins/eclipse/che-theia/7.11.0/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/7.11.0/meta.yaml
@@ -58,7 +58,8 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: "quay.io/eclipse/che-theia:7.11.0"
+    #  image: quay.io/eclipse/che-theia:7.11.0
+     image: quay.io/eclipse/che-theia@sha256:d0a7b5ed17656f3c76207dcede53165cf9eafd7d77f840165d5544bb8a502880
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins
@@ -78,7 +79,7 @@ spec:
          - exposedPort: 13131
          - exposedPort: 13132
          - exposedPort: 13133
-     memoryLimit: "512M"
+     memoryLimit: 512M
   initContainers:
   - name: remote-runtime-injector
     image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.11.0"

--- a/v3/plugins/eclipse/che-theia/next/meta.yaml
+++ b/v3/plugins/eclipse/che-theia/next/meta.yaml
@@ -58,7 +58,8 @@ spec:
         discoverable: false
   containers:
    - name: theia-ide
-     image: "quay.io/eclipse/che-theia:next"
+    #  image: quay.io/eclipse/che-theia:next
+     image: quay.io/eclipse/che-theia@sha256:b52eb0c46164f464f40bbacafddf9430b239500ddbaea22048f31ab16679d39c
      env:
          - name: THEIA_PLUGINS
            value: local-dir:///plugins
@@ -78,7 +79,7 @@ spec:
          - exposedPort: 13131
          - exposedPort: 13132
          - exposedPort: 13133
-     memoryLimit: "512M"
+     memoryLimit: 512M
   initContainers:
   - name: remote-runtime-injector
     image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:next"

--- a/v3/plugins/eclipse/cloud-shell/nightly/meta.yaml
+++ b/v3/plugins/eclipse/cloud-shell/nightly/meta.yaml
@@ -23,7 +23,8 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: che-machine-exec
-     image: "quay.io/eclipse/che-machine-exec:nightly"
+    #  image: quay.io/eclipse/che-machine-exec:nightly
+     image: quay.io/eclipse/che-machine-exec@sha256:df43419720820ec85df556ae89135b6f42b93869a0b72dc36b80564eb0e785cc
      ports:
        - exposedPort: 4444
      command: ['/go/bin/che-machine-exec', '--static', '/cloud-shell', '--url', '127.0.0.1:4444']

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.1.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.1.0/meta.yaml
@@ -12,9 +12,10 @@ category: Other
 firstPublicationDate: "2020-03-10"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.1.0-24dc4a3"
-      name: "vscode-kubernetes-tools"
-      memoryLimit: "1G"
+    # - image: quay.io/eclipse/che-sidecar-kubernetes-tooling:1.1.0-24dc4a3
+    - image: quay.io/eclipse/che-sidecar-kubernetes-tooling@sha256:13cdbf7eac3d6295e300b14ea4bc186b048c01a4fb094d8a9984078f2940c341
+      name: vscode-kubernetes-tools
+      memoryLimit: 1G
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-kubernetes-tools/vscode-kubernetes-tools-1.1.0.vsix
     - https://github.com/redhat-developer/vscode-yaml/releases/download/0.7.2/redhat.vscode-yaml-0.7.2.vsix

--- a/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.1.0/meta.yaml
+++ b/v3/plugins/ms-kubernetes-tools/vscode-kubernetes-tools/1.1.0/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2020-03-10"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.1.0-31a8464"
+    - image: "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.1.0-24dc4a3"
       name: "vscode-kubernetes-tools"
       memoryLimit: "1G"
   extensions:

--- a/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
+++ b/v3/plugins/ms-python/python/2019.5.18875/meta.yaml
@@ -13,8 +13,9 @@ category: Language
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-python:3.7.3-8f39348"
+  # - image: quay.io/eclipse/che-sidecar-python:3.7.3-8f39348
+  - image: quay.io/eclipse/che-sidecar-python@sha256:9d910486a81d92ebdeaab4c2fc71546bee23ff7e3a986fdb9df4e458819cb958
     name: vscode-python
-    memoryLimit: '512Mi'
+    memoryLimit: 512Mi
   extensions:
   - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-python/python-2019.5.18875.vsix

--- a/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
@@ -12,9 +12,10 @@ category: Language
 firstPublicationDate: '2019-09-19'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-go:1.12.9-f82cdd5"
+    # - image: quay.io/eclipse/che-sidecar-go:1.12.9-f82cdd5
+    - image: quay.io/eclipse/che-sidecar-go@sha256:765f811a4c88a77ace7dc09e5a488824356493376fa722e3cd3421108974dcd6
       name: vscode-go
-      memoryLimit: '512Mi'
+      memoryLimit: 512Mi
       env:
       - name: GOPATH
         value: /go:$(CHE_PROJECTS_ROOT)

--- a/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
+++ b/v3/plugins/ms-vscode/go/0.11.4/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: '2019-09-19'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-go:1.12.9-652ad19"
+    - image: "quay.io/eclipse/che-sidecar-go:1.12.9-f82cdd5"
       name: vscode-go
       memoryLimit: '512Mi'
       env:

--- a/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.33.0/meta.yaml
@@ -13,8 +13,9 @@ category: Debugger
 firstPublicationDate: '2019-06-20'
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
+  # - image: quay.io/eclipse/che-sidecar-node:10-0cb5d78
+  - image: quay.io/eclipse/che-sidecar-node@sha256:0370b2c3d52d31c9fd52bff3edb84bd36bbcc2aff6224957d6dd94935843ee59
     name: vscode-node-debug
-    memoryLimit: '512Mi'
+    memoryLimit: 512Mi
   extensions:
   - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-node-debug2/node-debug2-1.33.0.vsix

--- a/v3/plugins/pizzafactory/vscode-libra-move/0.0.10/meta.yaml
+++ b/v3/plugins/pizzafactory/vscode-libra-move/0.0.10/meta.yaml
@@ -12,8 +12,9 @@ category: Language
 repository: https://github.com/pizzafactory-contorno/vscode-libra-move/
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
       name: vscode-libra-move
-      memoryLimit: "512Mi"
+      memoryLimit: 512Mi
   extensions:
     - https://github.com/pizzafactory-contorno/vscode-libra-move/releases/download/v0.0.10-ddc0d3d/vscode-libra-move-0.0.10.vsix

--- a/v3/plugins/pizzafactory/xtend-lang/0.1.0/meta.yaml
+++ b/v3/plugins/pizzafactory/xtend-lang/0.1.0/meta.yaml
@@ -12,8 +12,9 @@ category: Language
 repository: https://github.com/PizzaFactory/xtend-ide-extensions/
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
       name: vscode-xtend-lang
-      memoryLimit: "768Mi"
+      memoryLimit: 768Mi
   extensions:
     - https://github.com/PizzaFactory/xtend-ide-extensions/releases/download/v0.1.0/xtend-lang-0.1.0.vsix

--- a/v3/plugins/pizzafactory/xtext-lang/0.4.0/meta.yaml
+++ b/v3/plugins/pizzafactory/xtext-lang/0.4.0/meta.yaml
@@ -12,8 +12,9 @@ category: Language
 repository: https://github.com/PizzaFactory/xtext-ide-extensions/
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
       name: vscode-xtext-lang
-      memoryLimit: "768Mi"
+      memoryLimit: 768Mi
   extensions:
     - https://github.com/PizzaFactory/xtext-ide-extensions/releases/download/v0.4.0/xtext-lang-0.4.0.vsix

--- a/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.6/meta.yaml
+++ b/v3/plugins/redhat-developer/che-omnisharp-plugin/0.0.6/meta.yaml
@@ -12,9 +12,10 @@ category: Language
 firstPublicationDate: "2020-01-05"
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78"
+  # - image: quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78
+  - image: quay.io/eclipse/che-sidecar-dotnet@sha256:5c0957a726a0cafb4ffa9e757425128e3f702123d11c5e673ff8ee58c712aea2
     name: theia-omnisharp
-    memoryLimit: "1024Mi"
+    memoryLimit: 1024Mi
     volumes:
     - mountPath: "/home/theia/.nuget"
       name: nuget

--- a/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.3/meta.yaml
+++ b/v3/plugins/redhat-developer/netcoredbg-theia-plugin/0.0.3/meta.yaml
@@ -12,8 +12,9 @@ category: Debugger
 firstPublicationDate: "2020-01-05"
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78"
+  # - image: quay.io/eclipse/che-sidecar-dotnet:2.2.105-2fd6e78
+  - image: quay.io/eclipse/che-sidecar-dotnet@sha256:5c0957a726a0cafb4ffa9e757425128e3f702123d11c5e673ff8ee58c712aea2
     name: theia-netcoredbg
-    memoryLimit: "512Mi"
+    memoryLimit: 512Mi
   extensions:
     - https://github.com/redhat-developer/netcoredbg-theia-plugin/releases/download/v0.0.3/netcoredbg_theia_plugin.theia

--- a/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/0.0.13/meta.yaml
@@ -12,8 +12,9 @@ category: Other
 firstPublicationDate: '2019-09-12'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-a38cb0c"
+    # - image: quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-a38cb0c
+    - image: quay.io/eclipse/che-sidecar-dependency-analytics@sha256:0708b3c63d2065ef96667cacec9a46570f00fcb0f107df3e902ac444e68e1170
       name: dependency-analytics
-      memoryLimit: "512Mi"
+      memoryLimit: 512Mi
   extensions:
     - https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/releases/download/0.0.13/redhat.fabric8-analytics-0.0.13.vsix

--- a/v3/plugins/redhat/java/0.57.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.57.0/meta.yaml
@@ -12,9 +12,10 @@ category: Language
 firstPublicationDate: "2020-02-20"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
       name: vscode-java
-      memoryLimit: "1500Mi"
+      memoryLimit: 1500Mi
       volumes:
       - mountPath: "/home/theia/.m2"
         name: m2

--- a/v3/plugins/redhat/java11/0.57.0/meta.yaml
+++ b/v3/plugins/redhat/java11/0.57.0/meta.yaml
@@ -12,9 +12,10 @@ category: Language
 firstPublicationDate: "2020-02-20"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
+    # - image: quay.io/eclipse/che-sidecar-java:11-f76ca45
+    - image: quay.io/eclipse/che-sidecar-java@sha256:54a5f721588455403d8c2a81d1fbc8fef2c6a32aead44f2fb3e24a8a1fddb9a2
       name: vscode-java
-      memoryLimit: "1500Mi"
+      memoryLimit: 1500Mi
       volumes:
       - mountPath: "/home/theia/.m2"
         name: m2

--- a/v3/plugins/redhat/java8/0.57.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.57.0/meta.yaml
@@ -12,9 +12,10 @@ category: Language
 firstPublicationDate: "2020-02-20"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
       name: vscode-java
-      memoryLimit: "1500Mi"
+      memoryLimit: 1500Mi
       volumes:
       - mountPath: "/home/theia/.m2"
         name: m2

--- a/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
+++ b/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
@@ -12,7 +12,8 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-php:7-5c5ecc5"
+    # - image: quay.io/eclipse/che-sidecar-php:7-5c5ecc5
+    - image: quay.io/eclipse/che-sidecar-php@sha256:e4f1db4b5bc641485f42a5e0534c37894042c5302acfb1fefcfdf6d659aa7925
       name: php-debugger
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-php-debug/php-debug-1.13.0.vsix

--- a/v3/plugins/redhat/php/1.0.14/meta.yaml
+++ b/v3/plugins/redhat/php/1.0.14/meta.yaml
@@ -12,7 +12,8 @@ category: Language
 firstPublicationDate: "2020-01-14"
 spec:
   containers:
-    - image: "eclipse/che-remote-plugin-php7:next"
-      memoryLimit: "1000Mi"
+    # - image: eclipse/che-remote-plugin-php7:next
+    - image: docker.io/eclipse/che-remote-plugin-php7@sha256:edcaa67f112c0e9fc3214ceca0a9d95a026315727d7101570e85de3d74e5a5b7
+      memoryLimit: 1000Mi
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-intelephense/vscode-intelephense-client-1.0.14.vsix

--- a/v3/plugins/redhat/quarkus-java8/1.3.0a/meta.yaml
+++ b/v3/plugins/redhat/quarkus-java8/1.3.0a/meta.yaml
@@ -12,9 +12,10 @@ category: Language
 firstPublicationDate: "2020-02-12"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
       name: vscode-quarkus
-      memoryLimit: "1500Mi"
+      memoryLimit: 1500Mi
       volumes:
       - mountPath: "/home/theia/.m2"
         name: m2

--- a/v3/plugins/redhat/rhamt/0.0.23/meta.yaml
+++ b/v3/plugins/redhat/rhamt/0.0.23/meta.yaml
@@ -23,7 +23,8 @@ spec:
     attributes:
       protocol: http
   containers:
-  - image: "docker.io/windup3/rhamt-vscode-extension:java8"
+  # - image: docker.io/windup3/rhamt-vscode-extension:java8
+  - image: docker.io/windup3/rhamt-vscode-extension@sha256:565cc74880f6021e52fab281348795ccddfa7c70dfae38da95c21c461e5c7dc7
     name: rhamt-extension
     memoryLimit: 1500Mi
     ports:

--- a/v3/plugins/redhat/vscode-apache-camel/0.0.22/meta.yaml
+++ b/v3/plugins/redhat/vscode-apache-camel/0.0.22/meta.yaml
@@ -12,8 +12,9 @@ category: Language
 firstPublicationDate: '2020-01-10'
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
+  # - image: quay.io/eclipse/che-sidecar-java:11-f76ca45
+  - image: quay.io/eclipse/che-sidecar-java@sha256:54a5f721588455403d8c2a81d1fbc8fef2c6a32aead44f2fb3e24a8a1fddb9a2
     name: vscode-apache-camel
-    memoryLimit: "300Mi"
+    memoryLimit: 300Mi
   extensions:
   - https://download.jboss.org/jbosstools/vscode/stable/vscode-apache-camel/vscode-apache-camel-0.0.22-167.vsix

--- a/v3/plugins/redhat/vscode-camelk/0.0.13/meta.yaml
+++ b/v3/plugins/redhat/vscode-camelk/0.0.13/meta.yaml
@@ -12,9 +12,10 @@ category: Language
 firstPublicationDate: '2020-03-24'
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-camelk:0.0.13-c3287d6"
+  # - image: quay.io/eclipse/che-sidecar-camelk:0.0.13-c3287d6
+  - image: quay.io/eclipse/che-sidecar-camelk@sha256:7f338b75da4f3870b5945ad9e0d3679f9fbc9a04fc8cf6b1467a4a6f64412b3a
     name: vscode-camelk
-    memoryLimit: "1G"
+    memoryLimit: 1G
   extensions:
   - https://download.jboss.org/jbosstools/vscode/stable/vscode-camelk/vscode-camelk-0.0.13-403.vsix
   - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-kubernetes-tools/vscode-kubernetes-tools-1.1.0.vsix

--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.2/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.2/meta.yaml
@@ -12,9 +12,10 @@ category: Other
 firstPublicationDate: "2019-12-04"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.2-2601509"
-      name: "vscode-openshift-connector"
-      memoryLimit: "512Mi"
+    # - image: quay.io/eclipse/che-sidecar-openshift-connector:0.1.2-2601509
+    - image: quay.io/eclipse/che-sidecar-openshift-connector@sha256:8e4403ef1f7f74af3568abd60ccf1b959e2f43bef0001ba7a77ca5f8bc0d5a0e
+      name: vscode-openshift-connector
+      memoryLimit: 512Mi
   extensions:
     - https://github.com/redhat-developer/vscode-openshift-tools/releases/download/v0.1.2/openshift-connector-0.1.2-420.vsix
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-kubernetes-tools/vscode-kubernetes-tools-1.0.9.vsix

--- a/v3/plugins/redhat/vscode-wsdl2rest/0.0.11/meta.yaml
+++ b/v3/plugins/redhat/vscode-wsdl2rest/0.0.11/meta.yaml
@@ -12,7 +12,8 @@ category: Other
 firstPublicationDate: "2020-01-13"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
-      memoryLimit: "256Mi"
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
+      memoryLimit: 256Mi
   extensions:
     - https://download.jboss.org/jbosstools/vscode/stable/vscode-wsdl2rest/vscode-wsdl2rest-0.0.11-106.vsix

--- a/v3/plugins/redhat/vscode-xml/0.11.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-xml/0.11.0/meta.yaml
@@ -12,8 +12,9 @@ category: Language
 firstPublicationDate: "2020-04-15"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"
+    # - image: quay.io/eclipse/che-sidecar-java:11-f76ca45
+    - image: quay.io/eclipse/che-sidecar-java@sha256:54a5f721588455403d8c2a81d1fbc8fef2c6a32aead44f2fb3e24a8a1fddb9a2
       name: vscode-xml
-      memoryLimit: "768Mi"
+      memoryLimit: 768Mi
   extensions:
     - https://github.com/redhat-developer/vscode-xml/releases/download/0.11.0/redhat.vscode-xml-0.11.0.vsix

--- a/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.4.0/meta.yaml
@@ -12,8 +12,9 @@ category: Language
 firstPublicationDate: "2019-04-19"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
+    # - image: quay.io/eclipse/che-sidecar-node:10-0cb5d78
+    - image: quay.io/eclipse/che-sidecar-node@sha256:0370b2c3d52d31c9fd52bff3edb84bd36bbcc2aff6224957d6dd94935843ee59
       name: vscode-yaml
-      memoryLimit: "256Mi"
+      memoryLimit: 256Mi
   extensions:
     - https://github.com/redhat-developer/vscode-yaml/releases/download/0.4.0/redhat.vscode-yaml-0.4.0.vsix

--- a/v3/plugins/sonarsource/sonarlint-vscode/0.0.2/meta.yaml
+++ b/v3/plugins/sonarsource/sonarlint-vscode/0.0.2/meta.yaml
@@ -12,8 +12,9 @@ category: Linter
 repository: https://www.sonarlint.org/
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"
+    # - image: quay.io/eclipse/che-sidecar-java:8-0cfbacb
+    - image: quay.io/eclipse/che-sidecar-java@sha256:4fb35b4e112a05c82353ad0e1f5eb35d1ba204be475b72f3c753b0e26c9e668d
       name: vscode-sonarlint
-      memoryLimit: "512Mi"
+      memoryLimit: 512Mi
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/sonarlint-vscode/sonarlint-vscode-1.13.0.vsix

--- a/v3/plugins/testthedocs/vale/0.9.1/meta.yaml
+++ b/v3/plugins/testthedocs/vale/0.9.1/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2020-01-30"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-vale:0.9.1-82a757a"
+    - image: "quay.io/eclipse/che-sidecar-vale:0.9.1-9cc9d68"
       name: "vscode-vale"
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/testthedocs/vale/0.9.1/meta.yaml
+++ b/v3/plugins/testthedocs/vale/0.9.1/meta.yaml
@@ -12,8 +12,9 @@ category: Other
 firstPublicationDate: "2020-01-30"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-vale:0.9.1-9cc9d68"
-      name: "vscode-vale"
-      memoryLimit: "512Mi"
+    # - image: quay.io/eclipse/che-sidecar-vale:0.9.1-9cc9d68
+    - image: quay.io/eclipse/che-sidecar-vale@sha256:96ed03f5219b837f1e3ba2f7d3404e866b06a62960eee6a5ce41f0c8b02bdd24
+      name: vscode-vale
+      memoryLimit: 512Mi
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-vale/vale-0.9.1.vsix

--- a/v3/plugins/ws-skeleton/eclipseide/4.9.0/meta.yaml
+++ b/v3/plugins/ws-skeleton/eclipseide/4.9.0/meta.yaml
@@ -20,8 +20,9 @@ spec:
         type: ide
   containers:
    - name: eclipse-ide
-     image: "docker.io/wsskeleton/eclipse-broadway"
+    #  image: docker.io/wsskeleton/eclipse-broadway
+     image: docker.io/wsskeleton/eclipse-broadway@sha256:89fddccbbe64183f91384917673e362c4854a86af6361d4dbb78565c9d1bf706
      mountSources: true
      ports:
          - exposedPort: 5000
-     memoryLimit: "2048M"
+     memoryLimit: 2048M

--- a/v3/plugins/ws-skeleton/jupyter/5.7.0/meta.yaml
+++ b/v3/plugins/ws-skeleton/jupyter/5.7.0/meta.yaml
@@ -20,11 +20,12 @@ spec:
         type: ide
   containers:
    - name: jupyter-notebook
-     image: "docker.io/ksmster/che-editor-jupyter:5.7.0"
+    #  image: docker.io/ksmster/che-editor-jupyter:5.7.0
+     image: docker.io/ksmster/che-editor-jupyter@sha256:83439ae9edcaa3a97536742315a7912f93e499f49847da094c480031eae4ba47
      env:
          - name: JUPYTER_NOTEBOOK_DIR
            value: /projects
      mountSources: true
      ports:
          - exposedPort: 8888
-     memoryLimit: "512M"
+     memoryLimit: 512M


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

### What does this PR do?

Changes tags on digests when referencing docker images

Only `latest` and `next` versions of the plugins were updated.

The sheet with a list of digests for each tag
https://docs.google.com/spreadsheets/d/191DLLyb01-3M54y0MFElFEGyGrTpAwprJEk6UFNlPdM/edit?usp=sharing

Old references were left in the comments to be able to check.
We can remove them before merging this PR.

Solves the issue https://github.com/eclipse/che/issues/16047
