### PR TITLE
Do not serve CloudShell resources by che-machine-exec plugin

### DIFF
--- a/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
+++ b/v3/plugins/eclipse/che-machine-exec-plugin/nightly/meta.yaml
@@ -27,4 +27,4 @@ spec:
      image: "quay.io/eclipse/che-machine-exec:nightly"
      ports:
        - exposedPort: 4444
-     command: ['/go/bin/che-machine-exec', '--static', '/cloud-shell', '--url', '127.0.0.1:4444']
+     command: ['/go/bin/che-machine-exec', '--url', '127.0.0.1:4444']


### PR DESCRIPTION
### What does this PR do?
:warning: It should not influence anything but still I would postpone the merge of this PR until 7.13.0 release is done but if there are other opinions - I'm OK with merging it as well.

Do not serve CloudShell resources by che-machine-exec plugin.

At some point, che-machine-exec was designed to optionally serve static resources to have an ability to reuse it for cloud-shell. And then probably by mistake cloud-shell came to che-machine-exec-plugin that is supposed to be used only as WebSocket API frontend for Theia Extension. So, now we have an ability to open CloudShell in a dedicated tab when we start Theia based workspace, and it's more easter egg than expected feature ( which honestly does not work stable ).

So, this PR removes serving cloud-shell static resources by che-machine-exec.
Without changes in the PR:
![Screenshot_20200514_153231](https://user-images.githubusercontent.com/5887312/81935582-8c368500-95f9-11ea-8e8a-99711abc2ee2.png)
With changes in PR:
![Screenshot_20200514_153739](https://user-images.githubusercontent.com/5887312/81935624-98badd80-95f9-11ea-9ee5-1d7df207de71.png)

P.S. CloudShell editor is still available as standalone CheEditor.