### PR TITLE
Update vale sidecar to use sidecar image with Alpine 3.11.6

### DIFF
--- a/v3/plugins/testthedocs/vale/0.9.1/meta.yaml
+++ b/v3/plugins/testthedocs/vale/0.9.1/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2020-01-30"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-vale:0.9.1-82a757a"
+    - image: "quay.io/eclipse/che-sidecar-vale:0.9.1-ad53ccf"
       name: "vscode-vale"
       memoryLimit: "512Mi"
   extensions:


### PR DESCRIPTION
See che-dockerfiles/che-sidecar-vale/pull/12

Signed-off-by: Eric Williams <ericwill@redhat.com>
