### PR TITLE
Fix shellcheck errors in .ci directory

### DIFF
--- a/.ci/che-cert_generation.sh
+++ b/.ci/che-cert_generation.sh
@@ -14,7 +14,8 @@
 #Declare CN
 export CA_CN=eclipse-che-signer
 
-export DOMAIN=*.$(minishift ip).nip.io
+DOMAIN="*.$(minishift ip).nip.io"
+export DOMAIN
 
 #Create Root Key
 openssl genrsa -out rootCA.key 4096


### PR DESCRIPTION
### What does this PR do?
Resolves the shellcheck errors that have been causing [failed CI jobs](https://app.circleci.com/pipelines/github/eclipse/che-plugin-registry). It'll also stop the email I get on every merged commit :)

There should be no functional changes, but failing this CI step means errors are easier to include in other scripts in the repo.