### PR TITLE
Contribute a vscode-extensions.json file

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,1 +1,29 @@
-# PRs for new plugins
+# Adding a VS Code extension to Che
+Che uses a similar system to OpenVSX when it comes to adding VS Code extensions. In the root of this repository is a [`vscode-extensions.json`](./vscode-extensions.json) file. In order to add/update a VS Code extension in Che, simply add/edit this file with the relevant extension information.
+
+Here is the expected format of an [`vscode-extensions.json`](./vscode-extensions.json) entry:
+
+```js
+    {
+      // Repository URL to clone and publish from
+      "repository": "https://github.com/redhat-developer/vscode-yaml",
+      // Tag or SHA1 ID of the upstream repository that hosts the extension, usually corresponding to a version/snapshot/release.
+      "revision": "0.8.0"
+    },
+```
+
+Here are all the supported values, including optional ones:
+
+```js
+    {
+      // (OPTIONAL) The subfolder where the code to build the VS Code extension is located, in the event it's not located at the repository root.
+      "directory": "extension/vscode-yaml/",
+      // Repository URL to clone and publish from
+      "repository": "https://github.com/redhat-developer/vscode-yaml",
+      // Tag or SHA1 ID of the upstream repository that hosts the extension, usually corresponding to a version/snapshot/release.
+      "revision": "0.8.0"
+    },
+```
+The file is sorted alphabetically A - Z, based on the repository name (i.e. `vscode-yaml`).
+
+Automation is in progress to automate the testing and validation of extensions in this JSON file. Stay tuned for more updates as this work is ongoing.

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -1,152 +1,152 @@
 {
   "extensions": [
     {
-      "revision": "6.0.19",
-      "repository": "https://github.com/spgennard/vscode_cobol"
+      "repository": "https://github.com/asciidoctor/asciidoctor-vscode",
+      "revision": "v2.7.7"
     },
     {
-      "revision": "0.11.1",
-      "vsixDirectory": "clients/cobol-lsp-vscode-extension/",
-      "repository": "https://github.com/eclipse/che-che4z-lsp-for-cobol"
+      "repository": "https://github.com/camel-tooling/camel-lsp-client-vscode",
+      "revision": "0.0.24"
     },
     {
-      "revision": "0.9.1",
-      "repository": "https://github.com/eclipse/che-che4z-explorer-for-endevor"
+      "repository": "https://github.com/eclipse/che-che4z-explorer-for-endevor",
+      "revision": "0.9.1"
     },
     {
-      "revision": "0.11.0",
-      "vsixDirectory": "clients/vscode-hlasmplugin/",	
-      "repository": "https://github.com/eclipse/che-che4z-lsp-for-hlasm"
+      "directory": "clients/cobol-lsp-vscode-extension/",
+      "repository": "https://github.com/eclipse/che-che4z-lsp-for-cobol",
+      "revision": "0.11.1"
     },
     {
-      "revision": "2.1650-vsc1.39.2",
-      "repository": "https://github.com/cdr/code-server"
+      "directory": "clients/vscode-hlasmplugin/",
+      "repository": "https://github.com/eclipse/che-che4z-lsp-for-hlasm",
+      "revision": "0.11.0"
     },
     {
-      "revision": "v10.2.1",
-      "repository": "https://github.com/eamodio/vscode-gitlens"
+      "repository": "https://github.com/cdr/code-server",
+      "revision": "2.1650-vsc1.39.2"
     },
     {
-      "revision": "v2.7.7",
-      "repository": "https://github.com/asciidoctor/asciidoctor-vscode"
+      "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension",
+      "revision": "0.0.13"
     },
     {
-      "revision": "660a6102103745f8e9e5affaa06a29e73ce9065e",
-      "repository": "https://github.com/SebastianZaha/vscode-emacs-friendly"
+      "repository": "https://github.com/scalameta/metals-vscode",
+      "revision": "v1.9.0"
     },
     {
-      "revision": "0.2.0",
-      "repository": "https://github.com/MicroShed/mp-starter-vscode-ext"
+      "repository": "https://github.com/MicroShed/mp-starter-vscode-ext",
+      "revision": "0.2.0"
     },
     {
-      "revision": "1.2.0",
-      "repository": "https://github.com/Azure/vscode-kubernetes-tools"
+      "repository": "https://github.com/redhat-developer/netcoredbg-theia-plugin",
+      "revision": "v0.0.3"
     },
     {
-      "revision": "2019.5.18875",
-      "repository": "https://github.com/Microsoft/vscode-python"
+      "repository": "https://github.com/redhat-developer/omnisharp-theia-plugin",
+      "revision": "v0.0.6"
     },
     {
-      "revision": "0.14.4",
-      "repository": "https://github.com/golang/vscode-go"
+      "repository": "https://github.com/windup/rhamt-vscode-extension",
+      "revision": "ca5adb5786114250fb9d4cebe6a327fd8d4d793c"
     },
     {
-      "revision": "v1.42.3",
-      "repository": "https://github.com/Microsoft/vscode-node-debug2"
+      "repository": "https://github.com/VSCodeVim/Vim",
+      "revision": "v1.14.5"
     },
     {
-      "revision": "v0.8.0",
-      "repository": "https://github.com/microsoft/vscode-pull-request-github"
+      "repository": "https://github.com/camel-tooling/vscode-camelk",
+      "revision": "0.0.14"
     },
     {
-      "revision": "v0.0.10-ddc0d3d", 
-      "repository": "https://github.com/pizzafactory-contorno/vscode-libra-move"
+      "repository": "https://github.com/spgennard/vscode_cobol",
+      "revision": "6.0.19"
     },
     {
-      "revision": "v0.1.0",
-      "vsixDirectory": "xtend-vscode-extension/",
-      "repository": "https://github.com/PizzaFactory/xtend-ide-extensions"
+      "repository": "https://github.com/SebastianZaha/vscode-emacs-friendly",
+      "revision": "660a6102103745f8e9e5affaa06a29e73ce9065e"
     },
     {
-      "revision": "v0.4.0",
-      "vsixDirectory": "xtext-vscode-extension/",
-      "repository": "https://github.com/PizzaFactory/xtext-ide-extensions/"
+      "repository": "https://github.com/zowe/vscode-extension-for-zowe",
+      "revision": "v1.5.1"
     },
     {
-      "revision": "v0.0.6", 
-      "repository": "https://github.com/redhat-developer/omnisharp-theia-plugin"
+      "repository": "https://github.com/eamodio/vscode-gitlens",
+      "revision": "v10.2.1"
     },
     {
-      "revision": "v0.0.3", 
-      "repository": "https://github.com/redhat-developer/netcoredbg-theia-plugin"
+      "repository": "https://github.com/golang/vscode-go",
+      "revision": "0.14.4"
     },
     {
-      "revision": "0.0.13",
-      "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension"
+      "repository": "https://github.com/bmewburn/vscode-intelephense",
+      "revision": "v1.3.11"
     },
     {
-      "revision": "v0.63.0", 
-      "repository": "https://github.com/redhat-developer/vscode-java"
+      "repository": "https://github.com/redhat-developer/vscode-java",
+      "revision": "v0.63.0"
     },
     {
-      "revision": "v1.13.0", 
-      "repository": "https://github.com/felixfbecker/vscode-php-debug"
+      "repository": "https://github.com/Azure/vscode-kubernetes-tools",
+      "revision": "1.2.0"
     },
     {
-      "revision": "v1.3.11", 
-      "repository": "https://github.com/bmewburn/vscode-intelephense"
+      "repository": "https://github.com/pizzafactory-contorno/vscode-libra-move",
+      "revision": "v0.0.10-ddc0d3d"
     },
     {
-      "revision": "v0.0.10", 
-      "repository": "https://github.com/redhat-developer/vscode-project-initializer"
+      "repository": "https://github.com/Microsoft/vscode-node-debug2",
+      "revision": "v1.42.3"
     },
     {
-      "revision": "v1.3.0", 
-      "repository": "https://github.com/redhat-developer/vscode-quarkus"
+      "repository": "https://github.com/redhat-developer/vscode-openshift-tools",
+      "revision": "v0.1.5"
     },
     {
-      "revision": "ca5adb5786114250fb9d4cebe6a327fd8d4d793c", 
-      "repository": "https://github.com/windup/rhamt-vscode-extension"
+      "repository": "https://github.com/felixfbecker/vscode-php-debug",
+      "revision": "v1.13.0"
     },
     {
-      "revision": "0.0.24",
-      "repository": "https://github.com/camel-tooling/camel-lsp-client-vscode"
+      "repository": "https://github.com/redhat-developer/vscode-project-initializer",
+      "revision": "v0.0.10"
     },
     {
-      "revision": "0.0.14",
-      "repository": "https://github.com/camel-tooling/vscode-camelk"
+      "repository": "https://github.com/microsoft/vscode-pull-request-github",
+      "revision": "v0.8.0"
     },
     {
-      "revision": "v0.1.5",
-      "repository": "https://github.com/redhat-developer/vscode-openshift-tools"
+      "repository": "https://github.com/Microsoft/vscode-python",
+      "revision": "2019.5.18875"
     },
     {
-      "revision": "0.0.11",
-      "repository": "https://github.com/camel-tooling/vscode-wsdl2rest"
+      "repository": "https://github.com/redhat-developer/vscode-quarkus",
+      "revision": "v1.3.0"
     },
     {
-      "revision": "0.11.0",
-      "repository": "https://github.com/redhat-developer/vscode-xml"
+      "repository": "https://github.com/testthedocs/vscode-vale",
+      "revision": "0.9.1"
     },
     {
-      "revision": "0.8.0",
-      "repository": "https://github.com/redhat-developer/vscode-yaml"
+      "repository": "https://github.com/camel-tooling/vscode-wsdl2rest",
+      "revision": "0.0.11"
     },
     {
-      "revision": "v1.9.0",
-      "repository": "https://github.com/scalameta/metals-vscode"
+      "repository": "https://github.com/redhat-developer/vscode-xml",
+      "revision": "0.11.0"
     },
     {
-      "revision": "0.9.1",
-      "repository": "https://github.com/testthedocs/vscode-vale"
+      "repository": "https://github.com/redhat-developer/vscode-yaml",
+      "revision": "0.8.0"
     },
     {
-      "revision": "v1.5.1",
-      "repository": "https://github.com/zowe/vscode-extension-for-zowe"
+      "directory": "xtend-vscode-extension/",
+      "repository": "https://github.com/PizzaFactory/xtend-ide-extensions",
+      "revision": "v0.1.0"
     },
     {
-      "revision": "v1.14.5",
-      "repository": "https://github.com/VSCodeVim/Vim"
+      "directory": "xtext-vscode-extension/",
+      "repository": "https://github.com/PizzaFactory/xtext-ide-extensions/",
+      "revision": "v0.4.0"
     }
   ]
 }

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -1,0 +1,172 @@
+{
+  "extensions": [
+    {
+      "version": "6.0.19",
+      "repository": "https://github.com/spgennard/vscode_cobol"
+    },
+    {
+      "version": "0.11.1",
+      "vsixDir": "clients/cobol-lsp-vscode-extension/",
+      "repository": "https://github.com/eclipse/che-che4z-lsp-for-cobol"
+    },
+    {
+      "version": "0.9.1",
+      "repository": "https://github.com/eclipse/che-che4z-explorer-for-endevor"
+    },
+    {
+      "version": "0.11.0",
+      "vsixDir": "clients/vscode-hlasmplugin/",	
+      "repository": "https://github.com/eclipse/che-che4z-lsp-for-hlasm"
+    },
+    {
+      "version": "2.1650-vsc1.39.2",
+      "repository": "https://github.com/cdr/code-server"
+    },
+    {
+      "version": "10.2.1",
+      "checkout": "v10.2.1",
+      "repository": "https://github.com/eamodio/vscode-gitlens"
+    },
+    {
+      "version": "2.7.7",
+      "checkout": "v2.7.7",
+      "repository": "https://github.com/asciidoctor/asciidoctor-vscode"
+    },
+    {
+      "version": "0.9.0",
+      "checkout": "master",
+      "repository": "https://github.com/SebastianZaha/vscode-emacs-friendly"
+    },
+    {
+      "version": "0.2.0",
+      "repository": "https://github.com/MicroShed/mp-starter-vscode-ext"
+    },
+    {
+      "version": "1.2.0",
+      "repository": "https://github.com/Azure/vscode-kubernetes-tools"
+    },
+    {
+      "version": "2019.5.18875",
+      "repository": "https://github.com/Microsoft/vscode-python"
+    },
+    {
+      "version": "0.14.4",
+      "repository": "https://github.com/golang/vscode-go"
+    },
+    {
+      "version": "1.33.0",
+      "checkout": "v1.33.0",
+      "repository": "https://github.com/Microsoft/vscode-node-debug2"
+    },
+    {
+      "version": "0.8.0",
+      "checkout": "v0.8.0",
+      "repository": "https://github.com/microsoft/vscode-pull-request-github"
+    },
+    {
+      "version": "0.0.10",
+      "checkout": "v0.0.10-ddc0d3d", 
+      "repository": "https://github.com/pizzafactory-contorno/vscode-libra-move"
+    },
+    {
+      "version": "0.1.0",
+      "checkout": "v0.1.0",
+      "vsixDir": "xtend-vscode-extension/",
+      "repository": "https://github.com/PizzaFactory/xtend-ide-extensions"
+    },
+    {
+      "version": "0.4.0",
+      "checkout": "v0.4.0",
+      "vsixDir": "xtext-vscode-extension/",
+      "repository": "https://github.com/PizzaFactory/xtext-ide-extensions/"
+    },
+    {
+      "version": "0.0.6",
+      "checkout": "v0.0.6", 
+      "repository": "https://github.com/redhat-developer/omnisharp-theia-plugin"
+    },
+    {
+      "version": "0.0.3",
+      "checkout": "v0.0.3", 
+      "repository": "https://github.com/redhat-developer/netcoredbg-theia-plugin"
+    },
+    {
+      "version": "0.0.13",
+      "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension"
+    },
+    {
+      "version": "0.63.0",
+      "checkout": "v0.63.0", 
+      "repository": "https://github.com/redhat-developer/vscode-java"
+    },
+    {
+      "version": "1.13.0",
+      "checkout": "v1.13.0", 
+      "repository": "https://github.com/felixfbecker/vscode-php-debug"
+    },
+    {
+      "version": "1.3.11",
+      "checkout": "v1.3.11", 
+      "repository": "https://github.com/bmewburn/vscode-intelephense"
+    },
+    {
+      "version": "0.0.10",
+      "checkout": "v0.0.10", 
+      "repository": "https://github.com/redhat-developer/vscode-project-initializer"
+    },
+    {
+      "version": "1.3.0",
+      "checkout": "v1.3.0", 
+      "repository": "https://github.com/redhat-developer/vscode-quarkus"
+    },
+    {
+      "version": "0.0.23",
+      "checkout": "master", 
+      "repository": "https://github.com/windup/rhamt-vscode-extension"
+    },
+    {
+      "version": "0.0.24",
+      "repository": "https://github.com/camel-tooling/camel-lsp-client-vscode"
+    },
+    {
+      "version": "0.0.14",
+      "repository": "https://github.com/camel-tooling/vscode-camelk"
+    },
+    {
+      "version": "0.1.5",
+      "checkout": "v0.1.5",
+      "repository": "https://github.com/redhat-developer/vscode-openshift-tools"
+    },
+    {
+      "version": "0.0.11",
+      "repository": "https://github.com/camel-tooling/vscode-wsdl2rest"
+    },
+    {
+      "version": "0.11.0",
+      "repository": "https://github.com/redhat-developer/vscode-xml"
+    },
+    {
+      "version": "0.8.0",
+      "repository": "https://github.com/redhat-developer/vscode-yaml"
+    },
+    {
+      "version": "1.9.0",
+      "checkout": "v1.9.0",
+      "repository": "https://github.com/scalameta/metals-vscode"
+    },
+    {
+      "version": "0.9.1",
+      "repository": "https://github.com/testthedocs/vscode-vale"
+    },
+    {
+      "version": "1.5.1",
+      "checkout": "v1.5.1",
+      "repository": "https://github.com/zowe/vscode-extension-for-zowe"
+    },
+    {
+      "version": "1.14.5",
+      "checkout": "v1.14.5",
+      "repository": "https://github.com/VSCodeVim/Vim"
+    }
+  ]
+}

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -121,7 +121,7 @@
     },
     {
       "version": "0.0.23",
-      "checkout": "master", 
+      "checkout": "634e59e7800d46dfe4308295f615dc5d4032f4c6#diff-b9cfc7f2cdf78a7f4b91a753d10865a2", 
       "repository": "https://github.com/windup/rhamt-vscode-extension"
     },
     {

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -1,171 +1,151 @@
 {
   "extensions": [
     {
-      "version": "6.0.19",
+      "revision": "6.0.19",
       "repository": "https://github.com/spgennard/vscode_cobol"
     },
     {
-      "version": "0.11.1",
-      "vsixDir": "clients/cobol-lsp-vscode-extension/",
+      "revision": "0.11.1",
+      "vsixDirectory": "clients/cobol-lsp-vscode-extension/",
       "repository": "https://github.com/eclipse/che-che4z-lsp-for-cobol"
     },
     {
-      "version": "0.9.1",
+      "revision": "0.9.1",
       "repository": "https://github.com/eclipse/che-che4z-explorer-for-endevor"
     },
     {
-      "version": "0.11.0",
-      "vsixDir": "clients/vscode-hlasmplugin/",	
+      "revision": "0.11.0",
+      "vsixDirectory": "clients/vscode-hlasmplugin/",	
       "repository": "https://github.com/eclipse/che-che4z-lsp-for-hlasm"
     },
     {
-      "version": "2.1650-vsc1.39.2",
+      "revision": "2.1650-vsc1.39.2",
       "repository": "https://github.com/cdr/code-server"
     },
     {
-      "version": "10.2.1",
-      "checkout": "v10.2.1",
+      "revision": "v10.2.1",
       "repository": "https://github.com/eamodio/vscode-gitlens"
     },
     {
-      "version": "2.7.7",
-      "checkout": "v2.7.7",
+      "revision": "v2.7.7",
       "repository": "https://github.com/asciidoctor/asciidoctor-vscode"
     },
     {
-      "version": "0.9.0",
-      "checkout": "master",
+      "revision": "660a6102103745f8e9e5affaa06a29e73ce9065e",
       "repository": "https://github.com/SebastianZaha/vscode-emacs-friendly"
     },
     {
-      "version": "0.2.0",
+      "revision": "0.2.0",
       "repository": "https://github.com/MicroShed/mp-starter-vscode-ext"
     },
     {
-      "version": "1.2.0",
+      "revision": "1.2.0",
       "repository": "https://github.com/Azure/vscode-kubernetes-tools"
     },
     {
-      "version": "2019.5.18875",
+      "revision": "2019.5.18875",
       "repository": "https://github.com/Microsoft/vscode-python"
     },
     {
-      "version": "0.14.4",
+      "revision": "0.14.4",
       "repository": "https://github.com/golang/vscode-go"
     },
     {
-      "version": "1.33.0",
-      "checkout": "v1.33.0",
+      "revision": "v1.42.3",
       "repository": "https://github.com/Microsoft/vscode-node-debug2"
     },
     {
-      "version": "0.8.0",
-      "checkout": "v0.8.0",
+      "revision": "v0.8.0",
       "repository": "https://github.com/microsoft/vscode-pull-request-github"
     },
     {
-      "version": "0.0.10",
-      "checkout": "v0.0.10-ddc0d3d", 
+      "revision": "v0.0.10-ddc0d3d", 
       "repository": "https://github.com/pizzafactory-contorno/vscode-libra-move"
     },
     {
-      "version": "0.1.0",
-      "checkout": "v0.1.0",
-      "vsixDir": "xtend-vscode-extension/",
+      "revision": "v0.1.0",
+      "vsixDirectory": "xtend-vscode-extension/",
       "repository": "https://github.com/PizzaFactory/xtend-ide-extensions"
     },
     {
-      "version": "0.4.0",
-      "checkout": "v0.4.0",
-      "vsixDir": "xtext-vscode-extension/",
+      "revision": "v0.4.0",
+      "vsixDirectory": "xtext-vscode-extension/",
       "repository": "https://github.com/PizzaFactory/xtext-ide-extensions/"
     },
     {
-      "version": "0.0.6",
-      "checkout": "v0.0.6", 
+      "revision": "v0.0.6", 
       "repository": "https://github.com/redhat-developer/omnisharp-theia-plugin"
     },
     {
-      "version": "0.0.3",
-      "checkout": "v0.0.3", 
+      "revision": "v0.0.3", 
       "repository": "https://github.com/redhat-developer/netcoredbg-theia-plugin"
     },
     {
-      "version": "0.0.13",
+      "revision": "0.0.13",
       "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension"
     },
     {
-      "version": "0.63.0",
-      "checkout": "v0.63.0", 
+      "revision": "v0.63.0", 
       "repository": "https://github.com/redhat-developer/vscode-java"
     },
     {
-      "version": "1.13.0",
-      "checkout": "v1.13.0", 
+      "revision": "v1.13.0", 
       "repository": "https://github.com/felixfbecker/vscode-php-debug"
     },
     {
-      "version": "1.3.11",
-      "checkout": "v1.3.11", 
+      "revision": "v1.3.11", 
       "repository": "https://github.com/bmewburn/vscode-intelephense"
     },
     {
-      "version": "0.0.10",
-      "checkout": "v0.0.10", 
+      "revision": "v0.0.10", 
       "repository": "https://github.com/redhat-developer/vscode-project-initializer"
     },
     {
-      "version": "1.3.0",
-      "checkout": "v1.3.0", 
+      "revision": "v1.3.0", 
       "repository": "https://github.com/redhat-developer/vscode-quarkus"
     },
     {
-      "version": "0.0.23",
-      "checkout": "634e59e7800d46dfe4308295f615dc5d4032f4c6#diff-b9cfc7f2cdf78a7f4b91a753d10865a2", 
+      "revision": "ca5adb5786114250fb9d4cebe6a327fd8d4d793c", 
       "repository": "https://github.com/windup/rhamt-vscode-extension"
     },
     {
-      "version": "0.0.24",
+      "revision": "0.0.24",
       "repository": "https://github.com/camel-tooling/camel-lsp-client-vscode"
     },
     {
-      "version": "0.0.14",
+      "revision": "0.0.14",
       "repository": "https://github.com/camel-tooling/vscode-camelk"
     },
     {
-      "version": "0.1.5",
-      "checkout": "v0.1.5",
+      "revision": "v0.1.5",
       "repository": "https://github.com/redhat-developer/vscode-openshift-tools"
     },
     {
-      "version": "0.0.11",
+      "revision": "0.0.11",
       "repository": "https://github.com/camel-tooling/vscode-wsdl2rest"
     },
     {
-      "version": "0.11.0",
+      "revision": "0.11.0",
       "repository": "https://github.com/redhat-developer/vscode-xml"
     },
     {
-      "version": "0.8.0",
+      "revision": "0.8.0",
       "repository": "https://github.com/redhat-developer/vscode-yaml"
     },
     {
-      "version": "1.9.0",
-      "checkout": "v1.9.0",
+      "revision": "v1.9.0",
       "repository": "https://github.com/scalameta/metals-vscode"
     },
     {
-      "version": "0.9.1",
+      "revision": "0.9.1",
       "repository": "https://github.com/testthedocs/vscode-vale"
     },
     {
-      "version": "1.5.1",
-      "checkout": "v1.5.1",
+      "revision": "v1.5.1",
       "repository": "https://github.com/zowe/vscode-extension-for-zowe"
     },
     {
-      "version": "1.14.5",
-      "checkout": "v1.14.5",
+      "revision": "v1.14.5",
       "repository": "https://github.com/VSCodeVim/Vim"
     }
   ]


### PR DESCRIPTION
This file lists all extensions in the che-plugin-registry. By extension, I mean those Che plugins that use VS Code extensions.

The fields are basic (for now) but are as follows:
* revision: the tag or SHA1 ID of the upstream repository, capturing a certain version of the extension
* vsixDirectory (optional): the sub-directory where the extension is located (some repositories have multiple extensions in multiple folders)
* repository: the location of the upstream repository

This file is needed for eclipse/che#17014, which is part of a greater epic eclipse/che#15819.

Signed-off-by: Eric Williams <ericwill@redhat.com>