### PR TITLE
Deprecate older java related plugins

### DIFF
--- a/v3/plugins/redhat/java/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java/0.50.0/meta.yaml
@@ -10,6 +10,9 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-java
 category: Language
 firstPublicationDate: "2019-10-03"
+deprecate:
+  automigrate: true
+  migrateTo: redhat/java/latest
 spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"

--- a/v3/plugins/redhat/java11/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java11/0.50.0/meta.yaml
@@ -10,6 +10,9 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-java
 category: Language
 firstPublicationDate: "2019-10-03"
+deprecate:
+  automigrate: true
+  migrateTo: redhat/java11/latest
 spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-java:11-f76ca45"

--- a/v3/plugins/redhat/java8/0.50.0/meta.yaml
+++ b/v3/plugins/redhat/java8/0.50.0/meta.yaml
@@ -10,6 +10,9 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-java
 category: Language
 firstPublicationDate: "2019-10-03"
+deprecate:
+  automigrate: true
+  migrateTo: redhat/java8/latest
 spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"

--- a/v3/plugins/redhat/quarkus-java8/1.2.0b/meta.yaml
+++ b/v3/plugins/redhat/quarkus-java8/1.2.0b/meta.yaml
@@ -10,6 +10,9 @@ icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/redhat-developer/vscode-quarkus
 category: Language
 firstPublicationDate: "2020-02-06"
+deprecate:
+  automigrate: true
+  migrateTo: redhat/quarkus-java8/latest
 spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-java:8-0cfbacb"


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

### What does this PR do?

Deprecates older version of Java related plugins where appropriate in the context of https://github.com/eclipse/che/issues/17025