### PR TITLE
fix(entrypoint): fix image error

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -35,8 +35,9 @@ RUN chmod -R g+rwX /build
 
 # Build registry, copying meta.yamls and index.json from builder
 FROM docker.io/httpd:2.4.43-alpine AS registry
-# Allow htaccess
-RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
+RUN apk add --no-cache bash && \
+    # Allow htaccess
+    sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
     sed -i 's|Listen 80|Listen 8080|' /usr/local/apache2/conf/httpd.conf && \
     mkdir -p /var/www && ln -s /usr/local/apache2/htdocs /var/www/html && \
     chmod -R g+rwX /usr/local/apache2 && \


### PR DESCRIPTION
### What does this PR do?

upstream tag image has been updated https://github.com/docker-library/httpd/commit/ea20f356a6f7d5b22793d0a51d82d6fccd08a6aa

it removes build dependencies but we were using bash transitively and it fails
add bash

good news: the image is A LOT smaller !

related issue: https://github.com/eclipse/che/issues/17345

Change-Id: Id69a992a971414b6d64416ab9aaf9741b17dcca1
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

