### PR TITLE
WINDUP-2691 - deprecate rhamt. rhamt has been rebranded to mta.

### DIFF
--- a/v3/plugins/redhat/rhamt/0.0.23/meta.yaml
+++ b/v3/plugins/redhat/rhamt/0.0.23/meta.yaml
@@ -10,6 +10,9 @@ publisher: redhat
 repository: https://github.com/windup/rhamt-vscode-extension
 category: Other
 firstPublicationDate: "2020-03-27"
+deprecate:
+  automigrate: true
+  migrateTo: redhat/mta/latest
 spec:
   endpoints:
   - name: "configuration-endpoint"


### PR DESCRIPTION
Signed-off-by: John Steele <programjsteele@gmail.com>

### What does this PR do?

TODO