### PR TITLE
Use che-container-tools based sidecar image for vscode-openshift-connector

### DIFF
--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.5/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.5/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2020-05-20"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.5-70438d2"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.5-b4689f9"
       name: "vscode-openshift-connector"
       memoryLimit: "1500Mi"
       volumes:


### PR DESCRIPTION
Adds helm to the sidecar as well. 

Closes eclipse/che#16130

Signed-off-by: Eric Williams <ericwill@redhat.com>