### PR TITLE
Add ci scripts to check digest images in PR

### DIFF
--- a/.ci/digest-validation-pr.sh
+++ b/.ci/digest-validation-pr.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright (c) 2012-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+set -e
+
+# PR_FILES_CHANGED store all Modified/Created files in Pull Request.
+PR_FILES_CHANGED=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD origin/master)")
+export PR_FILES_CHANGED
+
+# filterPluginsYamls function filter yamls from PR into a new array => FILES_CHANGED_ARRAY.
+function filterDevFileYamls() {
+    local SCRIPT
+    SCRIPT=$(readlink -f "$0")
+
+    local ROOT_DIR
+    ROOT_DIR=$(dirname "$(dirname "$SCRIPT")");
+
+    for files in ${PR_FILES_CHANGED}
+    do  
+        # Filter only files which are in v3 folder and finish with .yaml extension
+        if [[ $files =~ ^v3.*meta.yaml$ ]]; then
+            echo "[INFO] Added/Changed new devfile in the current PR: ${files}"
+            FILES_CHANGED_ARRAY+=("${ROOT_DIR}/"$files)
+            export FILES_CHANGED_ARRAY
+        fi
+    done 
+}
+
+# checkDevFileImages get the container images from changed meta.yaml files in PR and check if they have digest.
+function checkDevFileImages() {
+    IMAGES=$(yq -r '..|.image?' "${FILES_CHANGED_ARRAY[@]}" | grep -v "null" | uniq)
+    export IMAGES
+
+    for image in ${IMAGES}
+    do
+        local DIGEST
+        DIGEST="$(skopeo inspect --tls-verify=false docker://"${image}" 2>/dev/null | jq -r '.Digest')"
+        if [ -z "${DIGEST}" ];
+        then
+            echo "[ERROR] Image ${image} doesn't contain an valid digest.Digest check script will fail."
+            exit 1
+        fi
+        echo "[INFO] Successfully checked image digest: ${image}"
+    done
+}
+
+filterDevFileYamls
+checkDevFileImages

--- a/.ci/digest-validation-pr.sh
+++ b/.ci/digest-validation-pr.sh
@@ -16,7 +16,7 @@ PR_FILES_CHANGED=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD o
 export PR_FILES_CHANGED
 
 # filterPluginsYamls function filter yamls from PR into a new array => FILES_CHANGED_ARRAY.
-function filterDevFileYamls() {
+function filterPluginsYamls() {
     local SCRIPT
     SCRIPT=$(readlink -f "$0")
 
@@ -27,15 +27,15 @@ function filterDevFileYamls() {
     do  
         # Filter only files which are in v3 folder and finish with .yaml extension
         if [[ $files =~ ^v3.*meta.yaml$ ]]; then
-            echo "[INFO] Added/Changed new devfile in the current PR: ${files}"
-            FILES_CHANGED_ARRAY+=("${ROOT_DIR}/"$files)
+            echo "[INFO] Added/Changed new plugins in the current PR: ${files}"
+            FILES_CHANGED_ARRAY+=("${ROOT_DIR}/""$files")
             export FILES_CHANGED_ARRAY
         fi
     done 
 }
 
-# checkDevFileImages get the container images from changed meta.yaml files in PR and check if they have digest.
-function checkDevFileImages() {
+# checkDecheckPluginsImagesvFileImages get the container images from changed meta.yaml files in PR and check if they have digest.
+function checkPluginsImages() {
     IMAGES=$(yq -r '..|.image?' "${FILES_CHANGED_ARRAY[@]}" | grep -v "null" | uniq)
     export IMAGES
 
@@ -52,5 +52,5 @@ function checkDevFileImages() {
     done
 }
 
-filterDevFileYamls
-checkDevFileImages
+filterPluginsYamls
+checkPluginsImages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  pull_request:
+    branches: 
+      - master
+jobs:
+  digest-validation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run script which checks container image digest
+      run: |
+        sudo pip install yq
+        /bin/bash .ci/devfile-images-check.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Run script which checks container image digest
       run: |
         sudo pip install yq
-        /bin/bash .ci/devfile-images-check.sh
+        /bin/bash .ci/digest-validation-pr.sh


### PR DESCRIPTION
Signed-off-by: flacatus <flacatus@redhat.com>

### What does this PR do?

This PR create a new ci script which basically check all new container images created/changed in the main.yaml files. This CI scripts will run using github actions. The job name is digest-validation.

I tested this job in one of my repo: flacatus/github-actions#4

What issues does this PR fix or reference?
Reference issue: eclipse/che#17368
