### PR TITLE
Add preliminary sidecar fields to vscode-extensions.json

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -21,7 +21,21 @@ Here are all the supported values, including optional ones:
       // Repository URL to clone and publish from
       "repository": "https://github.com/redhat-developer/vscode-yaml",
       // Tag or SHA1 ID of the upstream repository that hosts the extension, usually corresponding to a version/snapshot/release.
-      "revision": "0.8.0"
+      "revision": "0.8.0",
+      // (OPTIONAL) Details about the plugin's sidecar container, if one exists
+      "sidecar": {
+        // The image location
+        "image": "quay.io/eclipse/che-sidecar-node:10-0cb5d78",
+        // Source details about the Dockerfile that builds the sidecar image
+        "source": {
+          // Repository URL where the Dockerfile is located
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-node",
+          // (OPTIONAL) Tag or SHA1 ID of the sidecar repository, in the event that the Dockerfile is not located on the default branch
+          "revision": "10",
+          // (OPTIONAL) The subfolder where the Dockerfile is located, in the event that the Dockerfile is not located at the repository root
+          "directory": "./subfolder/foo"
+        }
+      }
     },
 ```
 The file is sorted alphabetically A - Z, based on the repository name (i.e. `vscode-yaml`).

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -11,7 +11,12 @@
     {
       "repository": "https://github.com/Azure/vscode-kubernetes-tools",
       "revision": "1.2.0",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-kubernetes-tooling"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-kubernetes-tooling:1.2.0-3ea57d5",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-kubernetes-tooling"
+        }
+      }
     },
     {
       "repository": "https://github.com/bash-lsp/bash-language-server",
@@ -21,25 +26,45 @@
     {
       "repository": "https://github.com/bmewburn/vscode-intelephense",
       "revision": "v1.3.11",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-php",
-      "dockerfileRevision": "7"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-php:7-5c5ecc5",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-php",
+          "revision": "7"
+        }
+      }
     },
     {
       "repository": "https://github.com/camel-tooling/camel-lsp-client-vscode",
       "revision": "0.0.26",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "11"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:11-f76ca45",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "11"
+        }
+      }
     },
     {
       "repository": "https://github.com/camel-tooling/vscode-camelk",
       "revision": "0.0.14",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-camelk"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-camelk:0.0.15-a578c4a",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-camelk"
+        }
+      }
     },
     {
       "repository": "https://github.com/camel-tooling/vscode-wsdl2rest",
       "revision": "0.0.11",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "8"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:8-0cfbacb",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "8"
+        }
+      }
     },
     {
       "repository": "https://github.com/cdr/code-server",
@@ -57,8 +82,13 @@
       "repository": "https://github.com/eclipse/che-che4z-lsp-for-cobol",
       "revision": "0.12.0",
       "directory": "clients/cobol-lsp-vscode-extension/",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "11"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:11-f76ca45",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "11"
+        }
+      }
     },
     {
       "repository": "https://github.com/eclipse/che-che4z-lsp-for-hlasm",
@@ -68,19 +98,34 @@
     {
       "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension",
       "revision": "0.1.0",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-dependency-analytics",
-      "dockerfileRevision": "0.0.13"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-a38cb0",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-dependency-analytics",
+          "revision": "0.0.13"
+        }
+      }
     },
     {
       "repository": "https://github.com/felixfbecker/vscode-php-debug",
       "revision": "v1.13.0",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-php",
-      "dockerfileRevision": "7"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-php:7-5c5ecc5",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-php",
+          "revision": "7"
+        }
+      }
     },
     {
       "repository": "https://github.com/golang/vscode-go",
       "revision": "v0.14.4",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-go"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-go:1.14.4-afebf70",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-go"
+        }
+      }
     },
     {
       "repository": "https://github.com/MicroShed/mp-starter-vscode-ext",
@@ -89,8 +134,13 @@
     {
       "repository": "https://github.com/Microsoft/vscode-node-debug2",
       "revision": "v1.42.3",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-node",
-      "dockerfileRevision": "10"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-node:10-0cb5d78",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-node",
+          "revision": "10"
+        }
+      }
     },
     {
       "repository": "https://github.com/microsoft/vscode-pull-request-github",
@@ -99,40 +149,70 @@
     {
       "repository": "https://github.com/Microsoft/vscode-python",
       "revision": "2019.5.18875",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-python",
-      "dockerfileRevision": "3.7.3"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-python:3.7.3-8f39348",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-python",
+          "revision": "3.7.3"
+        }
+      }
     },
     {
       "repository": "https://github.com/pizzafactory-contorno/vscode-libra-move",
       "revision": "v0.0.10-ddc0d3d",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "8"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:8-0cfbacb",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "8"
+        }
+      }
     },
     {
       "repository": "https://github.com/PizzaFactory/xtend-ide-extensions",
       "revision": "v0.1.0",
       "directory": "xtend-vscode-extension/",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "8"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:8-0cfbacb",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "8"
+        }
+      }
     },
     {
       "repository": "https://github.com/PizzaFactory/xtext-ide-extensions/",
       "revision": "v0.4.0",
       "directory": "xtext-vscode-extension/",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "8"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:8-0cfbacb",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "8"
+        }
+      }
     },
     {
       "repository": "https://github.com/redhat-developer/netcoredbg-theia-plugin",
       "revision": "v0.0.3",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-dotnet",
-      "dockerfileRevision": "3.1.301"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-dotnet:3.1.301-117e653",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-dotnet",
+          "revision": "3.1.301"
+        }
+      }
     },
     {
       "repository": "https://github.com/redhat-developer/omnisharp-theia-plugin",
       "revision": "v0.0.6",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-dotnet",
-      "dockerfileRevision": "3.1.301"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-dotnet:3.1.301-117e653",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-dotnet",
+          "revision": "3.1.301"
+        }
+      }
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-didact",
@@ -141,13 +221,23 @@
     {
       "repository": "https://github.com/redhat-developer/vscode-java",
       "revision": "v0.63.0",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "11"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:11-f76ca45",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "11"
+        }
+      }
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-openshift-tools",
       "revision": "v0.1.5",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-openshift-connector"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-openshift-connector:0.1.5-b4689f9",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-openshift-connector"
+        }
+      }
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-project-initializer",
@@ -156,20 +246,35 @@
     {
       "repository": "https://github.com/redhat-developer/vscode-quarkus",
       "revision": "v1.5.0",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "11"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:11-f76ca45",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "11"
+        }
+      }
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-xml",
       "revision": "0.13.0",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
-      "dockerfileRevision": "11"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-java:11-f76ca45",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-java",
+          "revision": "11"
+        }
+      }
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-yaml",
       "revision": "0.8.0",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-node",
-      "dockerfileRevision": "10"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-node:10-0cb5d78",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-node",
+          "revision": "10"
+        }
+      }
     },
     {
       "repository": "https://github.com/rogalmic/vscode-bash-debug",
@@ -178,8 +283,13 @@
     {
       "repository": "https://github.com/scalameta/metals-vscode",
       "revision": "v1.9.1",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-scala",
-      "dockerfileRevision": "0.9.0"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-scala:0.9.0-6a833ec",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-scala",
+          "revision": "0.9.0"
+        }
+      }
     },
     {
       "repository": "https://github.com/SebastianZaha/vscode-emacs-friendly",
@@ -188,7 +298,12 @@
     {
       "repository": "https://github.com/SonarSource/sonarlint-vscode",
       "revision": "1.16.0",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-sonarlint"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-sonarlint:1.16.0-4af5039",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-sonarlint"
+        }
+      }
     },
     {
       "repository": "https://github.com/spgennard/vscode_cobol",
@@ -197,7 +312,12 @@
     {
       "repository": "https://github.com/testthedocs/vscode-vale",
       "revision": "0.9.1",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-vale"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-vale:0.9.1-ad53ccf",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-vale"
+        }
+      }
     },
     {
       "repository": "https://github.com/VSCodeVim/Vim",
@@ -210,8 +330,13 @@
     {
       "repository": "https://github.com/zowe/vscode-extension-for-zowe",
       "revision": "v1.5.1",
-      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-node",
-      "dockerfileRevision": "10"
+      "sidecar": {
+        "image": "quay.io/eclipse/che-sidecar-node:10-0cb5d78",
+        "source": {
+          "repository": "https://github.com/che-dockerfiles/che-sidecar-node",
+          "revision": "10"
+        }
+      }
     }
   ]
 }

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -10,7 +10,8 @@
     },
     {
       "repository": "https://github.com/Azure/vscode-kubernetes-tools",
-      "revision": "1.2.0"
+      "revision": "1.2.0",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-kubernetes-tooling"
     },
     {
       "repository": "https://github.com/bash-lsp/bash-language-server",
@@ -19,19 +20,26 @@
     },
     {
       "repository": "https://github.com/bmewburn/vscode-intelephense",
-      "revision": "v1.3.11"
+      "revision": "v1.3.11",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-php",
+      "dockerfileRevision": "7"
     },
     {
       "repository": "https://github.com/camel-tooling/camel-lsp-client-vscode",
-      "revision": "0.0.26"
+      "revision": "0.0.26",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "11"
     },
     {
       "repository": "https://github.com/camel-tooling/vscode-camelk",
-      "revision": "0.0.14"
+      "revision": "0.0.14",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-camelk"
     },
     {
       "repository": "https://github.com/camel-tooling/vscode-wsdl2rest",
-      "revision": "0.0.11"
+      "revision": "0.0.11",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "8"
     },
     {
       "repository": "https://github.com/cdr/code-server",
@@ -48,7 +56,9 @@
     {
       "repository": "https://github.com/eclipse/che-che4z-lsp-for-cobol",
       "revision": "0.12.0",
-      "directory": "clients/cobol-lsp-vscode-extension/"
+      "directory": "clients/cobol-lsp-vscode-extension/",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "11"
     },
     {
       "repository": "https://github.com/eclipse/che-che4z-lsp-for-hlasm",
@@ -57,15 +67,20 @@
     },
     {
       "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension",
-      "revision": "0.1.0"
+      "revision": "0.1.0",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-dependency-analytics",
+      "dockerfileRevision": "0.0.13"
     },
     {
       "repository": "https://github.com/felixfbecker/vscode-php-debug",
-      "revision": "v1.13.0"
+      "revision": "v1.13.0",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-php",
+      "dockerfileRevision": "7"
     },
     {
       "repository": "https://github.com/golang/vscode-go",
-      "revision": "v0.14.4"
+      "revision": "v0.14.4",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-go"
     },
     {
       "repository": "https://github.com/MicroShed/mp-starter-vscode-ext",
@@ -73,7 +88,9 @@
     },
     {
       "repository": "https://github.com/Microsoft/vscode-node-debug2",
-      "revision": "v1.42.3"
+      "revision": "v1.42.3",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-node",
+      "dockerfileRevision": "10"
     },
     {
       "repository": "https://github.com/microsoft/vscode-pull-request-github",
@@ -81,29 +98,41 @@
     },
     {
       "repository": "https://github.com/Microsoft/vscode-python",
-      "revision": "2019.5.18875"
+      "revision": "2019.5.18875",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-python",
+      "dockerfileRevision": "3.7.3"
     },
     {
       "repository": "https://github.com/pizzafactory-contorno/vscode-libra-move",
-      "revision": "v0.0.10-ddc0d3d"
+      "revision": "v0.0.10-ddc0d3d",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "8"
     },
     {
       "repository": "https://github.com/PizzaFactory/xtend-ide-extensions",
       "revision": "v0.1.0",
-      "directory": "xtend-vscode-extension/"
+      "directory": "xtend-vscode-extension/",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "8"
     },
     {
       "repository": "https://github.com/PizzaFactory/xtext-ide-extensions/",
       "revision": "v0.4.0",
-      "directory": "xtext-vscode-extension/"
+      "directory": "xtext-vscode-extension/",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "8"
     },
     {
       "repository": "https://github.com/redhat-developer/netcoredbg-theia-plugin",
-      "revision": "v0.0.3"
+      "revision": "v0.0.3",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-dotnet",
+      "dockerfileRevision": "3.1.301"
     },
     {
       "repository": "https://github.com/redhat-developer/omnisharp-theia-plugin",
-      "revision": "v0.0.6"
+      "revision": "v0.0.6",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-dotnet",
+      "dockerfileRevision": "3.1.301"
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-didact",
@@ -111,11 +140,14 @@
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-java",
-      "revision": "v0.63.0"
+      "revision": "v0.63.0",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "11"
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-openshift-tools",
-      "revision": "v0.1.5"
+      "revision": "v0.1.5",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-openshift-connector"
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-project-initializer",
@@ -123,15 +155,21 @@
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-quarkus",
-      "revision": "v1.3.0"
+      "revision": "v1.5.0",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "11"
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-xml",
-      "revision": "0.13.0"
+      "revision": "0.13.0",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-java",
+      "dockerfileRevision": "11"
     },
     {
       "repository": "https://github.com/redhat-developer/vscode-yaml",
-      "revision": "0.8.0"
+      "revision": "0.8.0",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-node",
+      "dockerfileRevision": "10"
     },
     {
       "repository": "https://github.com/rogalmic/vscode-bash-debug",
@@ -139,7 +177,9 @@
     },
     {
       "repository": "https://github.com/scalameta/metals-vscode",
-      "revision": "v1.9.1"
+      "revision": "v1.9.1",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-scala",
+      "dockerfileRevision": "0.9.0"
     },
     {
       "repository": "https://github.com/SebastianZaha/vscode-emacs-friendly",
@@ -147,7 +187,8 @@
     },
     {
       "repository": "https://github.com/SonarSource/sonarlint-vscode",
-      "revision": "1.16.0"
+      "revision": "1.16.0",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-sonarlint"
     },
     {
       "repository": "https://github.com/spgennard/vscode_cobol",
@@ -155,7 +196,8 @@
     },
     {
       "repository": "https://github.com/testthedocs/vscode-vale",
-      "revision": "0.9.1"
+      "revision": "0.9.1",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-vale"
     },
     {
       "repository": "https://github.com/VSCodeVim/Vim",
@@ -167,7 +209,9 @@
     },
     {
       "repository": "https://github.com/zowe/vscode-extension-for-zowe",
-      "revision": "v1.5.1"
+      "revision": "v1.5.1",
+      "dockerfile": "https://github.com/che-dockerfiles/che-sidecar-node",
+      "dockerfileRevision": "10"
     }
   ]
 }


### PR DESCRIPTION
Initial step to add sidecar update checking for the [che-plugin-registry report](https://eclipse.github.io/che-plugin-registry/). Summary of fields:
* **dockerfile**: repository for the Dockerfile that builds the sidecar
* **dockerfileRevision**: (optional) checkout tag/SHA1-ID for the repository to build the sidecar image, in the event the sidecar repo is structured that way

Signed-off-by: Eric Williams <ericwill@redhat.com>
