### PR TITLE
Sidecar update checking

### DIFF
--- a/tools/automation/src/check-plugin-update-template.md
+++ b/tools/automation/src/check-plugin-update-template.md
@@ -1,8 +1,8 @@
 # Automated Plugin Report
 
 ### Report accurate as of: {{reportTime}} UTC / (took {{computeTime}}s)
-| Plugin Name | Repository | Registry Version | Upstream Version | Error |
-| ------ | ------ | ------ | ------ | ------
+| Plugin Name | Repository | Registry Version | Upstream Version | Registry Sidecar Image | Upstream Sidecar Image | Error
+| ------ | ------ | ------ | ------ | ------ | ------ | ------
 {{#each entries}}
-| {{this.extensionName}} | [{{this.repositoryName}}]({{this.repositoryName}}) | {{this.registryVersion}} | {{#if this.needsUpdating}}**{{/if}}{{this.upstreamVersion}}{{#if this.needsUpdating}}**{{/if}} | {{this.errors}} 
+| {{this.extensionName}} | [{{this.repositoryName}}]({{this.repositoryName}}) | {{this.registryVersion}} | {{#if this.extensionNeedsUpdating}}**{{/if}}{{this.upstreamVersion}}{{#if this.extensionNeedsUpdating}}**{{/if}} | [{{this.registrySidecarImage}}]({{this.sidecarLocation}}) | [{{#if this.sidecarNeedsUpdating}}**{{/if}}{{this.upstreamSidecarImage}}{{#if this.sidecarNeedsUpdating}}**{{/if}}]({{this.sidecarLocation}}) | {{this.errors}}
 {{/each}}

--- a/tools/automation/src/check-plugin-updates.ts
+++ b/tools/automation/src/check-plugin-updates.ts
@@ -16,23 +16,37 @@ import * as semver from 'semver';
 
 import simpleGit, { SimpleGit } from 'simple-git';
 
-const ROOT_DIR = '/tmp/repository';
+const EXTENSION_ROOT_DIR = '/tmp/extension_repository';
+const SIDECAR_ROOT_DIR = '/tmp/sidecar_repository';
 
 // struct for the array of vscode-extensions.json file
 export interface Extension {
   repository: string;
   revision: string;
   directory?: string;
+  sidecar?: {
+    image: string;
+    source: {
+      repository: string;
+      revision?: string;
+      directory?: string;
+    };
+  };
 }
 
 // Entry generated when inspecting an extension
 export interface Entry {
   repositoryName: string;
   clonePath: string;
+  sidecarClonePath?: string;
   extensionName?: string;
   registryVersion?: string;
   upstreamVersion?: string;
-  needsUpdating?: boolean;
+  extensionNeedsUpdating?: boolean;
+  registrySidecarImage?: string;
+  upstreamSidecarImage?: string;
+  sidecarLocation?: string;
+  sidecarNeedsUpdating?: boolean;
   errors: string[];
 }
 
@@ -52,17 +66,18 @@ export class Report {
     const start = moment();
     const { extensions } = JSON.parse(await fs.readFile('./../../vscode-extensions.json', 'utf-8'));
 
-    // cleanup folder
-    await fs.remove(ROOT_DIR);
+    // cleanup folders
+    await fs.remove(EXTENSION_ROOT_DIR);
+    await fs.remove(SIDECAR_ROOT_DIR);
 
-    // grab result in parallel
+    // grab results in parallel
     const entries: Entry[] = await Promise.all(
       extensions.map(
         async (extension: Extension): Promise<Entry> => {
           // path where to clone extension (remove all invalid characters)
           const cloneName = extension.repository.replace(/[^\w\s]/gi, '');
           const entry: Entry = {
-            clonePath: path.resolve(ROOT_DIR, cloneName),
+            clonePath: path.resolve(EXTENSION_ROOT_DIR, cloneName),
             repositoryName: extension.repository,
             errors: [],
           };
@@ -95,17 +110,69 @@ export class Report {
           packageJSON = JSON.parse(await fs.readFile(packageJSONPath, 'utf-8'));
           entry.registryVersion = packageJSON.version;
           if (!entry.upstreamVersion) {
-            entry.needsUpdating = false;
+            entry.extensionNeedsUpdating = false;
             return this.handleError(entry, `Failure: there is no upstream version`);
           } else if (!entry.registryVersion) {
-            entry.needsUpdating = false;
+            entry.extensionNeedsUpdating = false;
             return this.handleError(entry, `Failure: there is no registry version`);
           } else {
-            entry.needsUpdating = semver.gt(entry.upstreamVersion, entry.registryVersion);
+            entry.extensionNeedsUpdating = semver.gt(entry.upstreamVersion, entry.registryVersion);
           }
 
           // cleanup cloned directory for this extension
           await fs.remove(entry.clonePath);
+
+          // If the extension has a sidecar image, let's check it too
+          if (extension.sidecar) {
+            const sidecarCloneName = extension.sidecar.source.repository.replace(/[^\w\s]/gi, '');
+            // Create unique clone path for the sidecar, otherwise there may be collisions
+            entry.sidecarClonePath = path.resolve(SIDECAR_ROOT_DIR, sidecarCloneName, entry.clonePath);
+
+            await fs.remove(entry.sidecarClonePath);
+            // Clone sidecar repository
+            try {
+              await git.clone(extension.sidecar.source.repository, entry.sidecarClonePath);
+            } catch (err) {
+              return this.handleError(entry, `Error cloning sidecar repository: ${err}`);
+            }
+
+            const sidecarNameSplit = extension.sidecar.image.split(':');
+            entry.sidecarLocation = `https://${sidecarNameSplit[0]}`;
+            const registryImageVersion = sidecarNameSplit[1];
+            // Filter out cases that do not adhere to the sidecar naming scheme
+            if (
+              registryImageVersion &&
+              (!registryImageVersion.includes('latest') || !registryImageVersion.includes('next'))
+            ) {
+              let sidecarSHA1;
+              entry.registrySidecarImage = registryImageVersion;
+              // Run git rev-parse --short HEAD and get hash of the upstream image
+              try {
+                const gitRevision = extension.sidecar.source.revision
+                  ? `origin/${extension.sidecar.source.revision}`
+                  : 'HEAD';
+                sidecarSHA1 = await simpleGit(entry.sidecarClonePath).revparse(['--short', `${gitRevision}`]);
+              } catch (err) {
+                return this.handleError(entry, `Error executing git rev-parse in sidecar repository: ${err}`);
+              }
+              // Compare versions
+              let upstreamSidecarImageVersion;
+              if (extension.sidecar.source.revision) {
+                upstreamSidecarImageVersion = `${extension.sidecar.source.revision}-${sidecarSHA1}`;
+                entry.sidecarNeedsUpdating = registryImageVersion !== upstreamSidecarImageVersion;
+              } else {
+                const sidecarVersion = (await fs.readFile(path.join(entry.sidecarClonePath, 'VERSION'), 'utf-8')).split(
+                  /\r?\n/
+                )[0];
+                upstreamSidecarImageVersion = `${sidecarVersion}-${sidecarSHA1}`;
+              }
+              entry.upstreamSidecarImage = upstreamSidecarImageVersion;
+              entry.sidecarNeedsUpdating = registryImageVersion !== upstreamSidecarImageVersion;
+            } else {
+              return this.handleError(entry, `Error checking sidecar image versions: image name format not supported.`);
+            }
+            await fs.remove(entry.sidecarClonePath);
+          }
 
           console.log(`✅ ${extension.repository}`);
           return entry;
@@ -137,8 +204,9 @@ export class Report {
       console.log(`Failed to write the report file (./report/index.md)`);
     }
 
-    // cleanup root cloned path
-    await fs.remove(ROOT_DIR);
+    // cleanup root cloned paths
+    await fs.remove(EXTENSION_ROOT_DIR);
+    await fs.remove(SIDECAR_ROOT_DIR);
 
     return;
   }

--- a/tools/automation/src/check-plugin-updates.ts
+++ b/tools/automation/src/check-plugin-updates.ts
@@ -161,9 +161,8 @@ export class Report {
                 upstreamSidecarImageVersion = `${extension.sidecar.source.revision}-${sidecarSHA1}`;
                 entry.sidecarNeedsUpdating = registryImageVersion !== upstreamSidecarImageVersion;
               } else {
-                const sidecarVersion = (await fs.readFile(path.join(entry.sidecarClonePath, 'VERSION'), 'utf-8')).split(
-                  /\r?\n/
-                )[0];
+                const sidecarRepoVersion = await fs.readFile(path.join(entry.sidecarClonePath, 'VERSION'), 'utf-8');
+                const sidecarVersion = sidecarRepoVersion.replace(/\n/gi, '');
                 upstreamSidecarImageVersion = `${sidecarVersion}-${sidecarSHA1}`;
               }
               entry.upstreamSidecarImage = upstreamSidecarImageVersion;

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -99,7 +99,7 @@
       "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension",
       "revision": "0.1.0",
       "sidecar": {
-        "image": "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-a38cb0",
+        "image": "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-a38cb0c",
         "source": {
           "repository": "https://github.com/che-dockerfiles/che-sidecar-dependency-analytics",
           "revision": "0.0.13"


### PR DESCRIPTION
This PR adds support for checking of sidecar update status to the nightly che-plugin-registry report.

* New columns for registry sidecar, and upstream sidecar images
* Sidecar images are clickable links, which will take you to the image's repository
* Sidecar images that have a newer upstream version are bolded in the `Upstream Sidecar Image` column
* If a plugin has no sidecar, the sidecar related columns in the report are left blank

Signed-off-by: Eric Williams <ericwill@redhat.com>