### PR TITLE
Fix cdt-vscode revision field

### DIFF
--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -97,7 +97,7 @@
     },
     {
       "repository": "https://github.com/eclipse-cdt/cdt-vscode",
-      "revision": "0.0.7"
+      "revision": "2edfc3a3474bc7a732014e1a4631561b991f845a"
     },
     {
       "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension",


### PR DESCRIPTION
Currently the report looks like this:

![garbage_plugin_report](https://user-images.githubusercontent.com/6290632/89825903-52efb180-db23-11ea-84e3-56d0880fd1f0.png)

This is caused by cdt-vscode having the wrong revision.

Signed-off-by: Eric Williams <ericwill@redhat.com>