### PR TITLE
Fix regex used for validating environment variables

### DIFF
--- a/build/scripts/meta.yaml.schema
+++ b/build/scripts/meta.yaml.schema
@@ -138,7 +138,7 @@
                   "properties": {
                     "name": {
                       "type": "string",
-                      "pattern": "^[-._a-zA-Z0-9]+$"
+                      "pattern": "^[a-zA-Z][_a-zA-Z0-9]*$"
                     },
                     "value": {
                       "type": "string"
@@ -285,7 +285,7 @@
                   "properties": {
                     "name": {
                       "type": "string",
-                      "pattern": "^[-._a-zA-Z0-9]+$"
+                      "pattern": "^[a-zA-Z][_a-zA-Z0-9]*$"
                     },
                     "value": {
                       "type": "string"
@@ -386,7 +386,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "pattern": "^[-._a-zA-Z0-9]+$"
+                "pattern": "^[a-zA-Z][_a-zA-Z0-9]*$"
               },
               "value": {
                 "type": "string"


### PR DESCRIPTION
### What does this PR do?

Fixes the regex used for validating env vars in meta.yamls to not allow `-` and `.`.
