### PR TITLE
Update vscode-openshift-connector sidecar image

### DIFF
--- a/v3/plugins/redhat/vscode-openshift-connector/0.1.5/meta.yaml
+++ b/v3/plugins/redhat/vscode-openshift-connector/0.1.5/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: "2020-05-20"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.5-b4689f9"
+    - image: "quay.io/eclipse/che-sidecar-openshift-connector:0.1.5-620dbc7"
       name: "vscode-openshift-connector"
       memoryLimit: "1500Mi"
       volumes:

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -228,7 +228,7 @@
       "repository": "https://github.com/redhat-developer/vscode-openshift-tools",
       "revision": "v0.1.5",
       "sidecar": {
-        "image": "quay.io/eclipse/che-sidecar-openshift-connector:0.1.5-b4689f9",
+        "image": "quay.io/eclipse/che-sidecar-openshift-connector:0.1.5-620dbc7",
         "source": {
           "repository": "https://github.com/che-dockerfiles/che-sidecar-openshift-connector"
         }


### PR DESCRIPTION
New image has:
* Removed wget, used curl instead
* Fixed issue with oc missing from the container

See eclipse/che#17633

Signed-off-by: Eric Williams <ericwill@redhat.com>