### PR TITLE
Use node 12 images

### DIFF
--- a/v3/plugins/ms-vscode/node-debug2/1.42.3/meta.yaml
+++ b/v3/plugins/ms-vscode/node-debug2/1.42.3/meta.yaml
@@ -13,7 +13,7 @@ category: Debugger
 firstPublicationDate: '2020-06-23'
 spec:
   containers:
-  - image: "quay.io/eclipse/che-sidecar-node:10-89911cf"
+  - image: "quay.io/eclipse/che-sidecar-node:12-026416c"
     name: vscode-node-debug
     memoryLimit: '512Mi'
   extensions:

--- a/v3/plugins/redhat/dependency-analytics/0.1.0/meta.yaml
+++ b/v3/plugins/redhat/dependency-analytics/0.1.0/meta.yaml
@@ -12,7 +12,7 @@ category: Other
 firstPublicationDate: '2020-07-14'
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-ff8919f"
+    - image: "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-2f3b058"
       name: dependency-analytics
       memoryLimit: "512Mi"
   extensions:

--- a/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
+++ b/v3/plugins/redhat/php-debugger/1.13.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2019-04-16"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-php:7-fc377b6"
+    - image: "quay.io/eclipse/che-sidecar-php:7-9854327"
       name: php-debugger
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-php-debug/php-debug-1.13.0.vsix

--- a/v3/plugins/redhat/php/1.3.11/meta.yaml
+++ b/v3/plugins/redhat/php/1.3.11/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2020-05-26"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-php:7-fc377b6"
+    - image: "quay.io/eclipse/che-sidecar-php:7-9854327"
       memoryLimit: "1000Mi"
   extensions:
     - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-intelephense/vscode-intelephense-client-1.3.11.vsix

--- a/v3/plugins/redhat/vscode-yaml/0.8.0/meta.yaml
+++ b/v3/plugins/redhat/vscode-yaml/0.8.0/meta.yaml
@@ -12,7 +12,7 @@ category: Language
 firstPublicationDate: "2020-05-22"
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-node:10-89911cf"
+    - image: "quay.io/eclipse/che-sidecar-node:12-026416c"
       name: vscode-yaml
       memoryLimit: "256Mi"
   extensions:

--- a/v3/plugins/zowe/vscode-extension-for-zowe/1.5.1/meta.yaml
+++ b/v3/plugins/zowe/vscode-extension-for-zowe/1.5.1/meta.yaml
@@ -11,7 +11,7 @@ repository: https://github.com/zowe/vscode-extension-for-zowe
 category: Other
 spec:
   containers:
-    - image: "quay.io/eclipse/che-sidecar-node:10-89911cf"
+    - image: "quay.io/eclipse/che-sidecar-node:12-026416c"
       name: zowe-explorer
       memoryLimit: "512Mi"
       env:

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -27,7 +27,7 @@
       "repository": "https://github.com/bmewburn/vscode-intelephense",
       "revision": "v1.3.11",
       "sidecar": {
-        "image": "quay.io/eclipse/che-sidecar-php:7-fc377b6",
+        "image": "quay.io/eclipse/che-sidecar-php:7-9854327",
         "source": {
           "repository": "https://github.com/che-dockerfiles/che-sidecar-php"
         }
@@ -100,7 +100,7 @@
       "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension",
       "revision": "0.1.0",
       "sidecar": {
-        "image": "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-ff8919f",
+        "image": "quay.io/eclipse/che-sidecar-dependency-analytics:0.0.13-2f3b058",
         "source": {
           "repository": "https://github.com/che-dockerfiles/che-sidecar-dependency-analytics"
         }
@@ -110,7 +110,7 @@
       "repository": "https://github.com/felixfbecker/vscode-php-debug",
       "revision": "v1.13.0",
       "sidecar": {
-        "image": "quay.io/eclipse/che-sidecar-php:7-fc377b6",
+        "image": "quay.io/eclipse/che-sidecar-php:7-9854327",
         "source": {
           "repository": "https://github.com/che-dockerfiles/che-sidecar-php"
         }
@@ -134,7 +134,7 @@
       "repository": "https://github.com/Microsoft/vscode-node-debug2",
       "revision": "v1.42.3",
       "sidecar": {
-        "image": "quay.io/eclipse/che-sidecar-node:10-89911cf",
+        "image": "quay.io/eclipse/che-sidecar-node:12-026416c",
         "source": {
           "repository": "https://github.com/che-dockerfiles/che-sidecar-node"
         }
@@ -262,7 +262,7 @@
       "repository": "https://github.com/redhat-developer/vscode-yaml",
       "revision": "0.8.0",
       "sidecar": {
-        "image": "quay.io/eclipse/che-sidecar-node:10-89911cf",
+        "image": "quay.io/eclipse/che-sidecar-node:12-026416c",
         "source": {
           "repository": "https://github.com/che-dockerfiles/che-sidecar-node"
         }
@@ -322,7 +322,7 @@
       "repository": "https://github.com/zowe/vscode-extension-for-zowe",
       "revision": "v1.5.1",
       "sidecar": {
-        "image": "quay.io/eclipse/che-sidecar-node:10-89911cf",
+        "image": "quay.io/eclipse/che-sidecar-node:12-026416c",
         "source": {
           "repository": "https://github.com/che-dockerfiles/che-sidecar-node"
         }


### PR DESCRIPTION
Use node 12 as a base image, or in the case of che-sidecar-node, the main image.

Signed-off-by: Eric Williams <ericwill@redhat.com>