### PR TITLE
Disable Openshift OAuth in prcheck.

### DIFF
--- a/.ci/cico-happy-path-pr-test.sh
+++ b/.ci/cico-happy-path-pr-test.sh
@@ -31,6 +31,7 @@ spec:
     selfSignedCert: true
   auth:
     updateAdminPassword: false
+    openShiftoAuth: false
 EOL
 )"
 


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?

Disables OAuth. this is a quick fix to unblock PR check in this repo.