### PR TITLE
Do not break automated report formatting when error messages have carriage returns

### DIFF
--- a/tools/automation/src/check-plugin-updates.ts
+++ b/tools/automation/src/check-plugin-updates.ts
@@ -54,7 +54,9 @@ export interface Entry {
 export class Report {
   // log the error and cleanup clone folder
   async handleError(entry: Entry, error: string): Promise<Entry> {
-    entry.errors.push(error);
+    // remove any carriage return, etc from the error message
+    const cleanupError = error.replace(/(\r\n|\n|\r)/gm, '');
+    entry.errors.push(cleanupError);
     console.log(`❌ ${entry.repositoryName} error:`, entry.errors);
 
     // cleanup any clone folder


### PR DESCRIPTION
### What does this PR do?

Avoid https://github.com/eclipse/che/issues/17763 to happen again when invalid metadata are there


Change-Id: Ic0f9a4a1444ae2580d713023201a2f51b69f1cee
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
