### PR TITLE
Remove preceding slash to icons/extensions PR check

### DIFF
--- a/.github/workflows/icons-extensions-pr-check.yaml
+++ b/.github/workflows/icons-extensions-pr-check.yaml
@@ -12,7 +12,7 @@ name: Icon and extensions PR check
 on:
   pull_request:
     paths:
-    - '/v3/plugins/**'
+    - 'v3/plugins/**'
 
 jobs:
   build:


### PR DESCRIPTION
Currently the PR check isn't running to due a preceding slash in the path field.

Signed-off-by: Eric Williams <ericwill@redhat.com>