### PR TITLE
chore(shellcheck): Introduce shellcheck as a github action (to remove circle-ci)

### DIFF
--- a/.github/workflows/shellcheck-pr-check.yml
+++ b/.github/workflows/shellcheck-pr-check.yml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: shellcheck
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Clone source code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: ShellCheck
+      run: |
+        find . -type f -name "*.sh" | xargs shellcheck --external-sources


### PR DESCRIPTION
### What does this PR do?
Use shellcheck from github action

Related to https://github.com/eclipse/che/issues/17830

Change-Id: Ia8b30ca287a9c91711136c67282522ff57a728d0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

