### PR TITLE
Use tls for external plugin registry deployment on the Openshift.

### DIFF
--- a/deploy/openshift/che-plugin-registry.yml
+++ b/deploy/openshift/che-plugin-registry.yml
@@ -107,6 +107,9 @@ objects:
       app.kubernetes.io/instance: che
       app.kubernetes.io/component: plugin-registry
   spec:
+    tls:
+      termination:
+        edge
     to:
       kind: Service
       name: che-plugin-registry


### PR DESCRIPTION

### What does this PR do?
Use tls for external plugin registry deployment on the Openshift. User dashboard doesn't work with plugin registry without tls...

### Screenshot/screencast of this PR
none


### What issues does this PR fix or reference?
none. I played with external registry options and this quick fix.

### How to test this PR?
Deploy external plugin registry to the namespace `che-registries`:
```
$ oc new-project che-registries
$ oc new-app -f deploy/openshift/che-plugin-registry.yml -p IMAGE="quay.io/eclipse/che-plugin-registry" -p IMAGE_TAG="nightly" -p PULL_POLICY="Always" -n che-registries
```
Deploy Che using external registry:

```
$ chectl server:start -p openshift -n moon40 --plugin-registry-url=https://che-plugin-registry-che-registries.apps-crc.testing/v3
```
Create new workspace using user dashboard and go to plugins tab. List plugins should appear.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
