### PR TITLE
haskell needs more than 1.5gb of mem

### DIFF
--- a/v3/plugins/haskell/vscode-haskell/8.10.1/meta.yaml
+++ b/v3/plugins/haskell/vscode-haskell/8.10.1/meta.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-haskell:8.10.1-eccd503"
       name: vscode-haskell
-      memoryLimit: 1500Mi
+      memoryLimit: 3Gi
   extensions:
     - https://open-vsx.org/api/justusadam/language-haskell/3.3.0/file/justusadam.language-haskell-3.3.0.vsix
     - https://open-vsx.org/api/haskell/haskell/1.1.0/file/haskell.haskell-1.1.0.vsix

--- a/v3/plugins/haskell/vscode-haskell/8.10.2/meta.yaml
+++ b/v3/plugins/haskell/vscode-haskell/8.10.2/meta.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-haskell:8.10.2-a79c68a"
       name: vscode-haskell
-      memoryLimit: 1500Mi
+      memoryLimit: 3Gi
   extensions:
     - https://open-vsx.org/api/justusadam/language-haskell/3.3.0/file/justusadam.language-haskell-3.3.0.vsix
     - https://open-vsx.org/api/haskell/haskell/1.1.0/file/haskell.haskell-1.1.0.vsix

--- a/v3/plugins/haskell/vscode-haskell/8.8.4/meta.yaml
+++ b/v3/plugins/haskell/vscode-haskell/8.8.4/meta.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-haskell:8.8.4-14f1de9"
       name: vscode-haskell
-      memoryLimit: 1500Mi
+      memoryLimit: 3Gi
   extensions:
     - https://open-vsx.org/api/justusadam/language-haskell/3.3.0/file/justusadam.language-haskell-3.3.0.vsix
     - https://open-vsx.org/api/haskell/haskell/1.1.0/file/haskell.haskell-1.1.0.vsix


### PR DESCRIPTION
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>
preparing devfiles for devfile-registry I get "out of memory" errors and it seems like it can be solved using some extra arguments in the project's stack.yaml, BUT even so I think 1.5gb of ram is too small amount for a c-like build system. Thus giving it more resources may allow to work with bigger projects even in the free tier of che osio.
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>
