### PR TITLE
SCALA: keep cachedirs from sidecar

### DIFF
--- a/v3/plugins/scalameta/metals/1.9.4/meta.yaml
+++ b/v3/plugins/scalameta/metals/1.9.4/meta.yaml
@@ -15,17 +15,6 @@ spec:
     - image: "quay.io/eclipse/che-sidecar-scala:0.9.0-b92a5f9"
       name: vscode-metals
       memoryLimit: "1500Mi"
-      volumes:
-      - name: sbt
-        mountPath: "/home/theia/.sbt"
-      - name: ivy2
-        mountPath: "/home/theia/.ivy2"
-      - name: coursier
-        mountPath: "/home/theia/.cache/coursier"
-      - name: metals
-        mountPath: "/home/theia/.cache/metals"
-      - name: bloop
-        mountPath: "/home/theia/.cache/bloop"
   extensions:
     - https://github.com/scala/vscode-scala-syntax/releases/download/0.4.5/scala-lang.scala-0.4.5.vsix
     - https://github.com/scalameta/metals-vscode/releases/download/v1.9.4/scalameta.metals-1.9.4.vsix


### PR DESCRIPTION
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>
remove volume bindings to keep sidecar contents in caches. 
Closes https://github.com/eclipse/che/issues/18286
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>
