### PR TITLE
Scala: simplify the sidecar image

### DIFF
--- a/sidecars/scala/Dockerfile
+++ b/sidecars/scala/Dockerfile
@@ -24,27 +24,26 @@ RUN apk --no-cache add openjdk11-jre-headless --repository=http://dl-cdn.alpinel
 
 WORKDIR /projects
 
-ENV JAVA_HOME=/usr/lib/jvm/default-jvm/ \
-    SBT_VERSION="1.3.10" \
-    METALS_VERSION="0.9.0+10-f3f3e535-SNAPSHOT"
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm/
 
 RUN mkdir -p $HOME/.cache && ln -s $HOME/.cache /root/.cache && \
     mkdir -p $HOME/.ivy2 && ln -s $HOME/.ivy2 /root/.ivy2 && \
     mkdir -p $HOME/.sbt && ln -s $HOME/.sbt /root/.sbt && \
     curl -Ls https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > /usr/local/bin/sbt && \
     chmod 0755 /usr/local/bin/sbt && \
-    sbt -sbt-version $SBT_VERSION -212 -sbt-create about && \
-    rm -Rf ./* && \
-    curl -Ls https://raw.githubusercontent.com/coursier/coursier/gh-pages/coursier > /usr/local/bin/coursier && \
-    chmod 0755 /usr/local/bin/coursier && \
-    coursier launch -r sonatype:snapshots org.scalameta:metals_2.12:$METALS_VERSION --main scala.meta.metals.DownloadDependencies
+    curl -Ls https://raw.githubusercontent.com/lefou/millw/main/millw > /usr/local/bin/mill && \
+    chmod 0755 /usr/local/bin/mill && \
+    curl -Ls https://git.io/coursier-cli > /usr/local/bin/cs && \
+    chmod 0755 /usr/local/bin/cs && \
+    (echo "#!/usr/bin/env sh" && curl -L https://github.com/lihaoyi/Ammonite/releases/download/2.2.0/2.12-2.2.0) > /usr/local/bin/amm && \
+    chmod 0755 /usr/local/bin/amm
 
 ADD etc/entrypoint.sh /entrypoint.sh
 
 RUN for f in "/projects" "$HOME/.cache" "$HOME/.ivy2" "$HOME/.sbt"; do \
       echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
       chmod -R g+rwX ${f}; \
-    done 
+    done
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}


### PR DESCRIPTION
Install only
 * JRE
 * wrapper script for sbt and mill
 * coursier
 * ammonite

Anything else, the VS Code Metals extension installs itself

closes https://github.com/che-dockerfiles/che-sidecar-scala/pull/9
closes https://github.com/che-dockerfiles/che-sidecar-scala/pull/11

Signed-off-by: sideeffffect <ondra.pelech@gmail.com>

/cc @ericwill 