### PR TITLE
fix debug extension breakpoints

### DIFF
--- a/v3/plugins/bitlang/cobol/6.0.19/meta.yaml
+++ b/v3/plugins/bitlang/cobol/6.0.19/meta.yaml
@@ -6,7 +6,7 @@ type: VS Code extension
 displayName: COBOL
 title: COBOL
 description: COBOL, JCL, PL/I & DIR syntax support
-icon: https://raw.githubusercontent.com/spgennard/vscode_cobol_extension/v5.2.2/images/cobol.png
+icon: https://raw.githubusercontent.com/spgennard/vscode_cobol_extension/main/images/cobol.png
 repository: https://github.com/spgennard/vscode_cobol
 category: Language
 spec:

--- a/v3/plugins/bitlang/cobol/6.0.19/meta.yaml
+++ b/v3/plugins/bitlang/cobol/6.0.19/meta.yaml
@@ -6,7 +6,7 @@ type: VS Code extension
 displayName: COBOL
 title: COBOL
 description: COBOL, JCL, PL/I & DIR syntax support
-icon: https://raw.githubusercontent.com/spgennard/vscode_cobol/v5.2.2/images/cobol.png
+icon: https://raw.githubusercontent.com/spgennard/vscode_cobol_extension/v5.2.2/images/cobol.png
 repository: https://github.com/spgennard/vscode_cobol
 category: Language
 spec:

--- a/v3/plugins/haskell/vscode-haskell/8.10.2/meta.yaml
+++ b/v3/plugins/haskell/vscode-haskell/8.10.2/meta.yaml
@@ -18,4 +18,4 @@ spec:
   extensions:
     - https://open-vsx.org/api/justusadam/language-haskell/3.3.0/file/justusadam.language-haskell-3.3.0.vsix
     - https://open-vsx.org/api/haskell/haskell/1.1.0/file/haskell.haskell-1.1.0.vsix
-    - https://open-vsx.org/api/gattytto/phoityne-vscode/0.0.27/file/gattytto.phoityne-vscode-0.0.27.vsix
+    - https://open-vsx.org/api/gattytto/phoityne-vscode/0.0.28/file/gattytto.phoityne-vscode-0.0.28.vsix

--- a/v3/plugins/haskell/vscode-haskell/8.10.2/meta.yaml
+++ b/v3/plugins/haskell/vscode-haskell/8.10.2/meta.yaml
@@ -18,4 +18,4 @@ spec:
   extensions:
     - https://open-vsx.org/api/justusadam/language-haskell/3.3.0/file/justusadam.language-haskell-3.3.0.vsix
     - https://open-vsx.org/api/haskell/haskell/1.1.0/file/haskell.haskell-1.1.0.vsix
-    - https://open-vsx.org/api/gattytto/phoityne-vscode/0.0.26/file/gattytto.phoityne-vscode-0.0.26.vsix
+    - https://open-vsx.org/api/gattytto/phoityne-vscode/0.0.27/file/gattytto.phoityne-vscode-0.0.27.vsix

--- a/v3/plugins/haskell/vscode-haskell/8.10.2/meta.yaml
+++ b/v3/plugins/haskell/vscode-haskell/8.10.2/meta.yaml
@@ -14,7 +14,7 @@ spec:
   containers:
     - image: "quay.io/eclipse/che-sidecar-haskell:8.10.2-2fde373"
       name: vscode-haskell
-      memoryLimit: 3Gi
+      memoryLimit: 3072Mi
   extensions:
     - https://open-vsx.org/api/justusadam/language-haskell/3.3.0/file/justusadam.language-haskell-3.3.0.vsix
     - https://open-vsx.org/api/haskell/haskell/1.1.0/file/haskell.haskell-1.1.0.vsix

--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -367,7 +367,7 @@
       }
     },
     {
-      "repository": "https://github.com/spgennard/vscode_cobol",
+      "repository": "https://github.com/spgennard/vscode_cobol_extension",
       "revision": "6.0.19"
     },
     {


### PR DESCRIPTION
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>
avoid using haskell-debug-adapter and use phoityne-vscode instead
HDA doesn't accept breakpoints yet. 
Signed-off-by: Esteban Mañaricua <emanaricua@gmail.com>