### PR TITLE
fix(id): These plug-ins have theia as publisher so it should be fixed in their package.json

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -338,7 +338,8 @@ plugins:
       revision: v0.3.9
     extensions:
       - https://open-vsx.org/api/rogalmic/bash-debug/0.3.9/file/rogalmic.bash-debug-0.3.9.vsix
-  - repository:
+  - id: redhat-developer/netcoredbg-theia-plugin
+    repository:
       url: https://github.com/redhat-developer/netcoredbg-theia-plugin
       revision: v0.0.3
     sidecar:
@@ -347,7 +348,8 @@ plugins:
       memoryLimit: "512Mi"
     extensions:
       - https://github.com/redhat-developer/netcoredbg-theia-plugin/releases/download/v0.0.3/netcoredbg_theia_plugin.theia
-  - repository:
+  - id: redhat-developer/che-omnisharp-plugin
+    repository:
       url: https://github.com/redhat-developer/omnisharp-theia-plugin
       revision: v0.0.6
     sidecar:


### PR DESCRIPTION
### What does this PR do?
These plug-ins have theia as publisher so it should be fixed in their package.json
https://github.com/redhat-developer/omnisharp-theia-plugin/pull/13
https://github.com/redhat-developer/netcoredbg-theia-plugin/pull/13

As workaround, specify the id

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
Automatically generating meta.yaml from the current information is not enough as the id in the vsix/repository is not correct.

### How to test this PR?
Compare package.json publisher/name with what is expected in meta.yaml for these plugins

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I739ffd5758520fadbf085f610dd1c9cada0b8ebd
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
