### PR TITLE
fix(pr-icon-check): Handle the case with relative icon images

### DIFF
--- a/tools/pr-check/__mocks__/axios.ts
+++ b/tools/pr-check/__mocks__/axios.ts
@@ -7,9 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const axios: any = jest.createMockFromModule('axios');
 
-describe('Empty Test', () => {
-  test('basics', async () => {
-    expect('empty').toBeDefined();
-  });
-});
+module.exports = axios;

--- a/tools/pr-check/src/pr-check.ts
+++ b/tools/pr-check/src/pr-check.ts
@@ -16,6 +16,7 @@ import * as path from 'path';
 import simpleGit, { SimpleGit } from 'simple-git';
 
 import Axios from 'axios';
+import { IconCheck } from './pr-icon-check';
 
 const EXTENSION_ROOT_DIR = '/tmp/extension_repository';
 
@@ -59,7 +60,7 @@ export interface MetaYamlExtension {
 }
 
 const metaYamlFiles = glob.sync('./../../v3/plugins/**/*.yaml');
-
+const prIconCheck = new IconCheck();
 async function vscodeExtensionsFieldValidation() {
   const { extensions } = JSON.parse(await fs.readFile('./../../vscode-extensions.json', 'utf-8'));
   const vsCodeExtensions: VSCodeExtension[] = await Promise.all(
@@ -191,7 +192,7 @@ async function iconsExtensions404Check() {
           if (metaYamlObject.icon) {
             extension.icon = metaYamlObject.icon;
             try {
-              await Axios.head(metaYamlObject.icon);
+              prIconCheck.check(metaYamlObject.icon);
             } catch (err) {
               extension.error = true;
               extension.errorMessage = `Failed to download ${metaYamlObject.name}'s icon at ${metaYamlObject.icon}`;

--- a/tools/pr-check/src/pr-icon-check.ts
+++ b/tools/pr-check/src/pr-icon-check.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import simpleGit, { SimpleGit } from 'simple-git';
+
+import axios from 'axios';
+
+export class IconCheck {
+  private git: SimpleGit;
+
+  private gitRootDirectory: Promise<string>;
+
+  constructor() {
+    this.git = simpleGit();
+  }
+
+  async check(icon: string): Promise<void> {
+    if (!this.gitRootDirectory) {
+      this.gitRootDirectory = this.git.revparse(['--show-toplevel']);
+    }
+    const gitRootDir = await this.gitRootDirectory;
+
+    // relative path
+    if (icon.startsWith('/')) {
+      // check the file exists
+      const iconPath = path.join(gitRootDir, icon);
+      const exist = await fs.pathExists(iconPath);
+      if (!exist) {
+        throw new Error(`The icon with relative path ${icon} does not exists at ${iconPath}`);
+      }
+    } else {
+      await axios.head(icon);
+    }
+  }
+}

--- a/tools/pr-check/tests/pr-icon-check.spec.ts
+++ b/tools/pr-check/tests/pr-icon-check.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { IconCheck } from '../src/pr-icon-check';
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import axios from 'axios';
+
+describe('Icon', () => {
+  const prIconCheck = new IconCheck();
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  test('absolute icon', async () => {
+    const spyOnHead = jest.spyOn(axios, 'head');
+    const iconToTest = 'https://fake-icon.png';
+    await prIconCheck.check(iconToTest);
+    expect(spyOnHead).toBeCalled();
+    expect(spyOnHead.mock.calls[0][0]).toBe(iconToTest);
+  });
+
+  test('absolute invalid icon', async () => {
+    const iconToTest = 'https://fake-icon.png';
+    const spyOnHead = jest.spyOn(axios, 'head');
+    spyOnHead.mockImplementation(() => {
+      throw new Error('icon does not exists');
+    });
+    await expect(prIconCheck.check(iconToTest)).rejects.toThrow('icon does not exists');
+  });
+
+  test('relative icon', async () => {
+    const iconToTest = '/v3/images/eclipse-che-logo.png';
+    const spyOnHead = jest.spyOn(axios, 'head');
+    spyOnHead.mockResolvedValue(true);
+    await prIconCheck.check(iconToTest);
+
+    // do not call axios with relative icons
+    expect(spyOnHead).toBeCalledTimes(0);
+  });
+
+  test('relative invalid icon', async () => {
+    const iconToTest = '/v3/images/eclipse-che-not-exists.png';
+    const spyOnHead = jest.spyOn(axios, 'head');
+    spyOnHead.mockResolvedValue(true);
+    await expect(prIconCheck.check(iconToTest)).rejects.toThrow(
+      'The icon with relative path /v3/images/eclipse-che-not-exists.png does not exists at'
+    );
+    // do not call axios with relative icons
+    expect(spyOnHead).toBeCalledTimes(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Today PR check icon will only verify icon by using fetch on the icon but the icon can be in relative format like `/images` 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
Use relative icons in the meta.yaml
I also added some unit tests

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: Ia7e7446ba2a2f27023c955b018ebe5eb2a712486
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
