### PR TITLE
fix(sidecars): Use full history to grab sidecars hashes

### DIFF
--- a/.github/workflows/build-jobs.yml
+++ b/.github/workflows/build-jobs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Clone source code
         uses: actions/checkout@v1
         with:
-          fetch-depth: 10
+          fetch-depth: 0
 
       - name: Login to quay.io
         uses: docker/login-action@v1


### PR DESCRIPTION
### What does this PR do?
Without the full history, latest changes for sidecars is the last sha1 then it references invalid sha1 of che-plugin-sidecar


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
It references invalid sidecar images by analyzing `sidecars` folder

example:
```
$ docker run --rm -it --entrypoint=bash quay.io/eclipse/che-plugin-registry:nightly -c "cat /var/www/html/v3/plugins/redhat/java/latest/meta.yaml"
apiVersion: v2
publisher: redhat
name: java
version: latest
type: VS Code extension
displayName: Language Support for Java(TM) by Red Hat
title: Language Support for Java(TM) by Red Hat
description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support
  and more...
icon: /v3/images/redhat-java-icon.png
category: Programming Languages
repository: https://github.com/redhat-developer/vscode-java
firstPublicationDate: '2020-10-14'
deprecate:
  automigrate: true
  migrateTo: redhat/java11/latest
spec:
  containers:
    - image: quay.io/eclipse/che-plugin-sidecar:java-6072026
      name: vscode-java
      volumes:
        - name: m2
          mountPath: /home/theia/.m2
      memoryLimit: 1500Mi
  extensions:
    - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.69.0-2547.vsix
    - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
    - https://open-vsx.org/api/vscjava/vscode-java-test/0.24.0/file/vscjava.vscode-java-test-0.24.0.vsix
latestUpdateDate: "2020-12-07"
```

image that is referenced is `quay.io/eclipse/che-plugin-sidecar:java-6072026` which is invalid


### How to test this PR?
Building locally produce the expected behaviour as we've the full history

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I575d4b5a663ace8254b4639e888a5aa231a32e12
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
