### PR TITLE
chore(surge): Publish on surge.sh the content of each repository on each PR and add link in status check

### DIFF
--- a/.github/workflows/image-build-pr-check.yml
+++ b/.github/workflows/image-build-pr-check.yml
@@ -30,3 +30,30 @@ jobs:
         elif [[ "${{matrix.dist}}" == "rhel" ]]; then
           docker build -t che-plugin-registry-image -f ./build/dockerfiles/rhel.Dockerfile --target registry .
         fi  
+        docker create --name pluginRegistry che-plugin-registry-image sh
+        mkdir root-dir
+        docker cp pluginRegistry:/var/www/html/v3 root-dir/v3
+        docker rm -f pluginRegistry
+        cp root-dir/v3/plugins/index.json root-dir/index.json
+        tar zcvf content-${{matrix.dist}}.tgz -C root-dir .
+    - uses: actions/upload-artifact@v2
+      with:
+        name: plugin-registry-content-${{matrix.dist}}
+        path: content-${{matrix.dist}}.tgz
+  pull-request-info:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-20.04
+    needs: [image-build]
+    steps:
+     - name: Store PR info
+       run: |
+         echo "${{ github.event.number }}" > PR_NUMBER
+         echo "${{ github.event.pull_request.head.sha }}" > PR_SHA
+     - uses: actions/upload-artifact@v2
+       with:
+         name: pull-request-number
+         path: PR_NUMBER
+     - uses: actions/upload-artifact@v2
+       with:
+         name: pull-request-sha
+         path: PR_SHA

--- a/.github/workflows/publish-pr-check-content.yml
+++ b/.github/workflows/publish-pr-check-content.yml
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: Publish Registry Content
+
+on:
+  workflow_run:
+    workflows: ["Image Build PR check"]
+    types:
+      - completed
+
+jobs:
+  publish:
+    # only if it's a pull request
+    if: github.event.workflow_run.event == 'pull_request'
+    strategy:
+      matrix:
+        dist: [ 'alpine', 'rhel' ]
+    name: publish
+    runs-on: ubuntu-20.04
+    steps:
+      - name: download dist artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: plugin-registry-content-${{matrix.dist}}
+          path: content
+      - name: PR number
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: pull-request-number
+      - name: Grab pull request number
+        run: |
+          pr_number=$(cat "PR_NUMBER")
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "pr number invalid"
+            exit 1
+          fi
+          echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
+      - name: PR sha
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: pull-request-sha
+      - name: Grab pull request sha1
+        run: |
+          pr_sha=$(cat "PR_SHA")
+          echo "PR_SHA=$pr_sha" >> $GITHUB_ENV
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - name: publish
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: |
+          sudo apt-get install tree
+          npm install -g surge
+          mkdir unpacked
+          tar zxvf content/*.tgz -C unpacked/
+          # generate tree index on all directories
+          for directory in `find unpacked/ -type d`
+            do
+              (cd $directory && tree -H '.' -L 1 --noreport --charset utf-8 | sed '/<p class="VERSION">/,/<\/p>/d' > index.html)
+           done
+           # Make meta.yaml as index
+           for file in $(find unpacked -name 'meta.yaml' -type f)
+             do
+               PARENT_DIR=$(dirname $file);
+               cp ${PARENT_DIR}/meta.yaml ${PARENT_DIR}/index.html
+             done
+           export DEPLOY_DOMAIN=https://pr-check-${PR_NUMBER}-${{matrix.dist}}-che-plugin-registry.surge.sh
+           echo "DEPLOY_DOMAIN=$DEPLOY_DOMAIN" >> $GITHUB_ENV
+           surge ./unpacked --domain $DEPLOY_DOMAIN
+      - name: 'Comment PR'
+        uses: actions/github-script@v3.0.0
+        with:
+         script: |
+           const { repo: { owner, repo } } = context;
+           await github.repos.createCommitStatus({ owner, repo, sha: process.env.PR_SHA, state: "success", target_url: process.env.DEPLOY_DOMAIN, description: "Browse registry content (${{matrix.dist}}) live", context: "surge(${{matrix.dist}})"})


### PR DESCRIPTION
### What does this PR do?
Once images are built, grab the v3 folder, store it as artifacts of the PR
Then, in a workflow_run flow, grab artifacts and publish them on surge.sh

This way, there is no problem on accessing secrets

### Screenshot/screencast of this PR
It adds two extra checks with links on each PR (one with content from alpine, one with content from rhel)
![image](https://user-images.githubusercontent.com/436777/101516331-a82bba80-397f-11eb-8134-aa2238b8ccdc.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15819

### How to test this PR?
You may create a PR on my fork branch https://github.com/benoitf/che-plugin-registry/tree/publish-content but I'm not sure it works if it's not in main branch
So you can play on https://github.com/benoitf/surge-test


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I21e524f5eceab83e020e6e521d20c6e5777cfece
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
