### PR TITLE
fix(che-editors): Add missing entries in che-editors.yaml and fix couple of issues on volumes/exposedPort/id

### DIFF
--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -1,6 +1,12 @@
 version: 1.0.0
 editors:
   - id: eclipse/che-theia/next
+    title: Eclipse Theia development version.
+    displayName: theia-ide
+    description: Eclipse Theia, get the latest release each day.
+    icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
+    repository: https://github.com/eclipse/che-theia
+    firstPublicationDate: "2019-03-07"
     endpoints:
       - name: "theia"
         public: true
@@ -68,15 +74,21 @@ editors:
             value: "3130"
           - name: THEIA_HOST
             value: 127.0.0.1
-        volumes:
+        volumeMounts:
           - name: plugins
             path: "/plugins"
         mountSources: true
+        ports:
+          - exposedPort: 3100
+          - exposedPort: 3130
+          - exposedPort: 13131
+          - exposedPort: 13132
+          - exposedPort: 13133
         memoryLimit: "512M"
     initContainers:
       - name: remote-runtime-injector
         image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:next"
-        volumes:
+        volumeMounts:
           - name: remote-endpoint
             path: "/remote-endpoint"
             ephemeral: true
@@ -86,6 +98,12 @@ editors:
           - name: REMOTE_ENDPOINT_VOLUME_NAME
             value: remote-endpoint
   - id: eclipse/che-theia/7.23.0
+    title: Eclipse Theia
+    displayName: theia-ide
+    description: Eclipse Theia
+    icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
+    repository: https://github.com/eclipse/che-theia
+    firstPublicationDate: "2019-03-07"
     endpoints:
       - name: "theia"
         public: true
@@ -153,15 +171,21 @@ editors:
             value: "3130"
           - name: THEIA_HOST
             value: 127.0.0.1
-        volumes:
+        volumeMounts:
           - name: plugins
             path: "/plugins"
         mountSources: true
+        ports:
+          - exposedPort: 3100
+          - exposedPort: 3130
+          - exposedPort: 13131
+          - exposedPort: 13132
+          - exposedPort: 13133
         memoryLimit: "512M"
     initContainers:
       - name: remote-runtime-injector
         image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.23.0"
-        volumes:
+        volumeMounts:
           - name: remote-endpoint
             path: "/remote-endpoint"
             ephemeral: true
@@ -170,7 +194,13 @@ editors:
             value: /remote-endpoint/plugin-remote-endpoint
           - name: REMOTE_ENDPOINT_VOLUME_NAME
             value: remote-endpoint
-  - id: ws-skeleton/che-editor-jupyter/5.7.0
+  - id: ws-skeleton/jupyter/5.7.0
+    title: Jupyter Notebook as Editor for Eclipse Che
+    displayName: Jupyter Notebook
+    description: Jupyter Notebook as Editor for Eclipse Che
+    icon: https://jupyter.org/assets/main-logo.svg
+    repository: https://github.com/ws-skeleton/che-editor-jupyter/
+    firstPublicationDate: "2019-02-05"
     endpoints:
       - name: "jupyter"
         public: true
@@ -185,8 +215,16 @@ editors:
           - name: JUPYTER_NOTEBOOK_DIR
             value: /projects
         mountSources: true
+        ports:
+         - exposedPort: 8888
         memoryLimit: "512M"
   - id: dirigiblelabs/dirigible/3.4.0
+    title: Eclipse Dirigible for Eclipse Che
+    displayName: Eclipse Dirigible
+    description: Eclipse Dirigible as App Development Platform for Eclipse Che
+    icon: https://www.dirigible.io/img/dirigible.svg
+    repository: https://github.com/dirigiblelabs/dirigible-che-editor-plugin/
+    firstPublicationDate: "2019-02-05"
     endpoints:
       - name: "dirigible"
         public: true
@@ -218,9 +256,17 @@ editors:
             value: jdbc:h2:/projects/dirigible/h2
           - name: DIRIGIBLE_OPERATIONS_LOGS_ROOT_FOLDER_DEFAULT
             value: /usr/local/tomcat/logs
+        ports:
+          - exposedPort: 8080            
         mountSources: true
         memoryLimit: "1024M"
-  - id: che-incubator/che-editor-intellij-community/2020.2.2
+  - id: che-incubator/intellij-community/2020.2.2
+    title:  IntelliJ IDEA Community Edition (in browser using noVNC) as editor for Eclipse Che
+    displayName:  IntelliJ IDEA Community Edition
+    description:  IntelliJ IDEA Community Edition running on the Web with noVNC
+    icon: https://resources.jetbrains.com/storage/products/intellij-idea/img/meta/intellij-idea_logo_300x300.png
+    repository: https://github.com/che-incubator/che-editor-intellij-community
+    firstPublicationDate: "2020-09-29"
     endpoints:
       - name: "intellij"
         public: true
@@ -234,11 +280,19 @@ editors:
       - name: intellij-novnc
         image: "quay.io/che-incubator/che-editor-intellij-community:2020.2-cdc002c"
         mountSources: true
-        volumes:
+        volumeMounts:
           - name: idea-configuration
             path: "/JetBrains/IdeaIC"
+        ports:
+         - exposedPort: 8080
         memoryLimit: "2048M"
-  - id: ws-skeleton/che-editor-eclipseide/4.9.0
+  - id: ws-skeleton/eclipseide/4.9.0
+    displayName: Eclipse IDE
+    description: Eclipse running on the Web with Broadway
+    title: Eclipse IDE (in browser using Broadway) as editor for Eclipse Che
+    icon: https://cdn.freebiesupply.com/logos/large/2x/eclipse-11-logo-svg-vector.svg
+    repository: https://github.com/ws-skeleton/che-editor-eclipseide/
+    firstPublicationDate: "2019-02-05"
     endpoints:
       - name: "eclipse-ide"
         public: true
@@ -250,8 +304,16 @@ editors:
       - name: eclipse-ide
         image: "docker.io/wsskeleton/eclipse-broadway"
         mountSources: true
+        ports:
+          - exposedPort: 5000
         memoryLimit: "2048M"
   - id: cdr/code-server/3.6.2
+    title: Visual Studio Code - Web (code-server)
+    displayName: code-server
+    description: An open source distribution of Visual Studio Code as a cloud IDE
+    icon: https://raw.githubusercontent.com/sr229/discord-open-source/master/logos/code-server.svg 
+    repository: https://github.com/cdr/code-server
+    firstPublicationDate: "2020-11-03"
     endpoints:
       - name: "code-server"
         public: true
@@ -264,6 +326,8 @@ editors:
         image: "codercom/code-server:3.6.2"
         mountSources: true
         memoryLimit: "1024M"
-        volumes:
+        ports:
+         - exposedPort: 8080
+        volumeMounts:
           - name: 'user-data'
             path: '/home/coder/.local/share/code-server'


### PR DESCRIPTION
### What does this PR do?
Add some missing information to generate meta.yaml
For che-theia-plugins.yaml we were not adding some information as it's available from inside the vsix files but with editors there is no other source, so need to add the details.
Fix volumeMount name to match che-theia-plugins.yaml volumeMount declaration
Also some ids were not matchings the ids of the current plug-ins

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
che-editors.yaml was introduced as part of https://github.com/eclipse/che/issues/18214


### How to test this PR?
For now this `che-editors.yaml` file is not used but an upcoming PR will process this file.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: Ifd930bef786e1bcac819a66a18838b0831e568ef
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
