### PR TITLE
fix(build): simpleGit is not handling well parallel git executions

### DIFF
--- a/tools/build/src/sidecar/sidecar-docker-image.ts
+++ b/tools/build/src/sidecar/sidecar-docker-image.ts
@@ -23,7 +23,8 @@ export class SidecarDockerImage {
   private gitRootDirectory: string;
 
   constructor() {
-    this.git = simpleGit();
+    // reduce concurrent processes
+    this.git = simpleGit({ maxConcurrentProcesses: 1 });
   }
 
   @postConstruct()
@@ -47,6 +48,9 @@ export class SidecarDockerImage {
     };
     const result = await this.git.log(logOptions);
     const latest = result.latest;
+    if (!latest) {
+      throw new Error(`Unable to find result when executing ${JSON.stringify(logOptions)}`);
+    }
     const hash = latest.hash;
     return `${SidecarDockerImage.PREFIX_IMAGE}:${sidecarShortDirectory}-${hash}`;
   }

--- a/tools/build/tests/sidecar/sidecar-docker-image.spec.ts
+++ b/tools/build/tests/sidecar/sidecar-docker-image.spec.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable no-null/no-null */
 import 'reflect-metadata';
 
 import { Container } from 'inversify';
@@ -30,5 +31,16 @@ describe('Test Sidecar', () => {
     await sidecarDockerImage.init();
     const result = await sidecarDockerImage.getDockerImageFor('go');
     expect(result).toContain('quay.io/eclipse/che-plugin-sidecar:go-');
+  });
+
+  test('exception if no-log', async () => {
+    await sidecarDockerImage.init();
+    const git = sidecarDockerImage['git'];
+    const spyLog = jest.spyOn(git, 'log');
+    const logResult = { all: [], total: 1, latest: null } as any;
+    spyLog.mockResolvedValue(logResult);
+    await expect(sidecarDockerImage.getDockerImageFor('unknown')).rejects.toThrow(
+      'Unable to find result when executing'
+    );
   });
 });


### PR DESCRIPTION

### What does this PR do?
1 out of 10 builds are failing on rhel build with 'null' LogResult
It turns out that simpleGit may not handle well child_process/parallel stuff so avoid to use too many spawn execution
Also I added test-case for null value on LogResult

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Some PR builds are randomly failing

### How to test this PR?
Check that PR check are green (as it means we're able to build images)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I3cf15da66ea837e52ed7fd53bd86fe9c602ca6d5
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
