### PR TITLE
fix(sidecar-hash): On some environments, default short hash may not be 7 characters

### DIFF
--- a/tools/build/src/sidecar/sidecar-docker-image.ts
+++ b/tools/build/src/sidecar/sidecar-docker-image.ts
@@ -33,9 +33,9 @@ export class SidecarDockerImage {
   }
 
   async getDockerImageFor(sidecarShortDirectory: string): Promise<string> {
-    // use of short hash (abbreviated)
+    // Use long hash (and not short hash) as the value may vary across different git implementations and simple-git does not support abbrev parameter
     const format = {
-      hash: '%h',
+      hash: '%H',
     };
     const fullPathSideCarDirectory = path.resolve(this.gitRootDirectory, 'sidecars', sidecarShortDirectory);
 
@@ -52,6 +52,6 @@ export class SidecarDockerImage {
       throw new Error(`Unable to find result when executing ${JSON.stringify(logOptions)}`);
     }
     const hash = latest.hash;
-    return `${SidecarDockerImage.PREFIX_IMAGE}:${sidecarShortDirectory}-${hash}`;
+    return `${SidecarDockerImage.PREFIX_IMAGE}:${sidecarShortDirectory}-${hash.substring(0, 7)}`;
   }
 }

--- a/tools/build/tests/sidecar/sidecar-docker-image.spec.ts
+++ b/tools/build/tests/sidecar/sidecar-docker-image.spec.ts
@@ -43,4 +43,14 @@ describe('Test Sidecar', () => {
       'Unable to find result when executing'
     );
   });
+
+  test('check hash', async () => {
+    await sidecarDockerImage.init();
+    const git = sidecarDockerImage['git'];
+    const spyLog = jest.spyOn(git, 'log');
+    const logResult = { all: [], total: 1, latest: { hash: 'b8f0528ec5026a175114506b7c41ce4a1c833196' } } as any;
+    spyLog.mockResolvedValue(logResult);
+    const result = await sidecarDockerImage.getDockerImageFor('mycustom');
+    expect(result).toBe('quay.io/eclipse/che-plugin-sidecar:mycustom-b8f0528');
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Sets 'manually' the short hash length as it may vary across different runtime environments

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
on some env (@sunix env), `%h` is returning 8 characters instead of 7 but it may vary as well

### How to test this PR?
PR checks passed (also there is a new test-case)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I7e63ed0c73b39dd47fc590e76d488a3facbd7f85
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
