### PR TITLE
Upgrade Didact extension to 0.2.0

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -336,9 +336,9 @@ plugins:
       - https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v356aec7/vscode-xml-0.14.0.vsix
   - repository:
       url: https://github.com/redhat-developer/vscode-didact
-      revision: 0.1.18
+      revision: 0.2.0
     extensions:
-      - https://download.jboss.org/jbosstools/vscode/stable/vscode-didact/vscode-didact-0.1.18-47.vsix
+      - https://download.jboss.org/jbosstools/vscode/stable/vscode-didact/vscode-didact-0.2.0-119.vsix
   - repository:
       url: https://github.com/Azure/vscode-kubernetes-tools
       revision: 1.2.1


### PR DESCRIPTION
Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Updates the vscode-didact plugin to 0.2.0, which was just released

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![demo 2020-12-16 13-05](https://user-images.githubusercontent.com/530878/102505653-7da4c600-403f-11eb-9d3e-e207a5857a94.gif)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
- Updated AsciiDoc demo with better requirements label example. [FUSETOOLS2-800](https://issues.redhat.com/browse/FUSETOOLS2-800)
- Addressed issue where inner label on adoc was updating incorrectly. [FUSETOOLS2-877](https://issues.redhat.com/browse/FUSETOOLS2-877)
- Removed local copy of asciidoctor.css in favor of using upstream version directly. [FUSETOOLS2-874](https://issues.redhat.com/browse/FUSETOOLS2-874)
- Fixed issue with platform neutral paths preventing successful operation on Windows. [FUSETOOLS-887](https://issues.redhat.com/browse/FUSETOOLS2-887)
- Added Didact icon to Didact view tab and Didact version to footer. [FUSETOOLS2-919](https://issues.redhat.com/browse/FUSETOOLS2-919)
- Added Didact icon to tutorials in tutorials view. [FUSETOOLS2-920](https://issues.redhat.com/browse/FUSETOOLS2-920)

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Open a che instance that references this PR and verify that the tutorials that appear in the tutorials view are able to be opened and run

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
