### PR TITLE
feat(sidecar): Sidecar for asciidoc plugins that contains tools like asciidoc

### DIFF
--- a/sidecars/asciidoc/Dockerfile
+++ b/sidecars/asciidoc/Dockerfile
@@ -1,0 +1,18 @@
+FROM asciidoctor/docker-asciidoctor
+
+RUN apk --update --no-cache add \
+    jq
+
+ENV HOME=/home/theia
+
+RUN mkdir /projects ${HOME} && \
+    # Change permissions to let any arbitrary user
+    for f in "${HOME}" "/etc/passwd" "/projects"; do \
+      echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+      chmod -R g+rwX ${f}; \
+    done
+
+ADD etc/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}

--- a/sidecars/asciidoc/Dockerfile
+++ b/sidecars/asciidoc/Dockerfile
@@ -1,3 +1,13 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
 FROM asciidoctor/docker-asciidoctor
 
 RUN apk --update --no-cache add \

--- a/sidecars/asciidoc/PLATFORMS
+++ b/sidecars/asciidoc/PLATFORMS
@@ -1,0 +1,1 @@
+linux/amd64

--- a/sidecars/asciidoc/etc/entrypoint.sh
+++ b/sidecars/asciidoc/etc/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Copyright (c) 2018-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+set -e
+
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+export USER_ID
+export GROUP_ID
+
+if ! whoami >/dev/null 2>&1; then
+    echo "${USER_NAME:-user}:x:${USER_ID}:0:${USER_NAME:-user} user:${HOME}:/bin/sh" >> /etc/passwd
+fi
+
+# Grant access to projects volume in case of non root user with sudo rights
+if [ "${USER_ID}" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
+    sudo chown "${USER_ID}:${GROUP_ID}" /projects
+fi
+
+
+echo 'Setting "asciidoc.use_asciidoctorpdf" to true'
+mkdir -p "${CHE_PROJECTS_ROOT}"/.theia ;
+[ ! -f "${CHE_PROJECTS_ROOT}/.theia/settings.json" ] && echo "{}" > "${CHE_PROJECTS_ROOT}/.theia/settings.json"
+jq '. += {"asciidoc.use_asciidoctorpdf":true}' "${CHE_PROJECTS_ROOT}/.theia/settings.json" > /tmp/temp.json && mv /tmp/temp.json "${CHE_PROJECTS_ROOT}/.theia/settings.json"
+
+exec "$@"


### PR DESCRIPTION
Signed-off-by: Sun Seng David TAN <sutan@redhat.com>

### What does this PR do?
Provide a sidecar for the existing asciidoc plugin so task to export to PDF works well.
The sidecar contains asciidoc-topdf

### Screenshot/screencast of this PR
![Selection_114](https://user-images.githubusercontent.com/650571/102882400-9ef61f80-444e-11eb-9945-a8652a8d85d4.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16370

### How to test this PR?
- Use this devfile (that uses the sidecar built and pushed to my quay.io repo):
```yaml
apiVersion: 1.0.0
metadata:
  generateName: ascii-doc-
projects:
  - name: asciidoctor-che
    source:
      location: 'https://github.com/sunix/asciidoctor-che'
      type: git
      branch: master
components:
  - id: joaompinto/asciidoctor-vscode/latest
    type: chePlugin
    registryUrl: 'https://sunix-che-plugin-registry-dev-asciidoc.surge.sh/v3'
  - mountSources: true
    args:
      - sleep
      - infinity
    memoryLimit: 768Mi
    type: dockerimage
    image: quay.io/sunix/asciidoctor
    alias: asciidoctor
commands:
  - name: asciidoctor README.adoc
    actions:
      - workdir: /projects/asciidoctor-che
        type: exec
        command: asciidoctor README.adoc
        component: asciidoctor
  - name: asciidoctor-pdf README.adoc
    actions:
      - workdir: /projects/asciidoctor-che
        type: exec
        command: asciidoctor-pdf README.adoc
        component: asciidoctor
  - name: asciidoctor-epub3 README.adoc
    actions:
      - workdir: /projects/asciidoctor-che
        type: exec
        command: asciidoctor-epub3 README.adoc
        component: asciidoctor
```
- open asciidoc-che/README.adoc
- `F1` -> `Asciidoc: Export document to pdf`
- Choose a location
- The PDF file has been generated

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
