### PR TITLE
fix(plugins): add a sidecar with asciidoc-pdf to the asciidoc plugin

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -102,6 +102,14 @@ plugins:
       revision: v2.7.7
     extensions:
       - https://download.jboss.org/jbosstools/vscode/3rdparty/asciidoctor-vscode/asciidoctor-vscode-2.7.7.vsix
+    sidecar:
+      directory: asciidoc
+      name: asciidoctor-vscode
+      memoryLimit: '128Mi'
+      volumeMounts:
+        # this is a workaround for openshift3
+        - name: documents
+          path: "/documents"
   - repository:
       url: https://github.com/eamodio/vscode-gitlens
       revision: v10.2.1


### PR DESCRIPTION
### What does this PR do?
Add a sidecar with asciidoc-pdf to the asciidoc plugin, fixing the task `Asciidoc: Export document to pdf` that is currently failing to execute.

### Screenshot/screencast of this PR
![Selection_114](https://user-images.githubusercontent.com/650571/102882400-9ef61f80-444e-11eb-9945-a8652a8d85d4.png)

### What issues does this PR fix or reference?
Fix https://github.com/eclipse/che/issues/16370

requires https://github.com/eclipse/che-plugin-registry/pull/780


### How to test this PR?
The provided registry has been updated, using `quay.io/eclipse/che-plugin-sidecar:asciidoc-5337f80`
See https://sunix-che-plugin-registry-dev-asciidoc.surge.sh/v3/plugins/joaompinto/asciidoctor-vscode/latest/meta.yaml
```yaml
apiVersion: v2
publisher: joaompinto
name: asciidoctor-vscode
version: latest
type: VS Code extension
displayName: AsciiDoc
title: AsciiDoc
description: Provides rich language support for AsciiDoc.
icon: /v3/images/joaompinto-asciidoctor-vscode-icon.png
category: Programming Languages
repository: https://github.com/asciidoctor/asciidoctor-vscode
firstPublicationDate: '2020-01-06'
spec:
  containers:
    - image: quay.io/eclipse/che-plugin-sidecar:asciidoc-5337f80
      name: asciidoctor-vscode
      volumes:
        - name: documents
          mountPath: /documents
      memoryLimit: 128Mi
  extensions:
    - https://download.jboss.org/jbosstools/vscode/3rdparty/asciidoctor-vscode/asciidoctor-vscode-2.7.7.vsix
latestUpdateDate: "2020-12-23"
```

- Use this devfile (the provided registry has been updated, using ^^ ):
```yaml
apiVersion: 1.0.0
metadata:
  generateName: ascii-doc-
projects:
  - name: asciidoctor-che
    source:
      location: 'https://github.com/sunix/asciidoctor-che'
      type: git
      branch: master
components:
  - id: joaompinto/asciidoctor-vscode/latest
    type: chePlugin
    registryUrl: 'https://sunix-che-plugin-registry-dev-asciidoc.surge.sh/v3'
  - mountSources: true
    args:
      - sleep
      - infinity
    memoryLimit: 768Mi
    type: dockerimage
    image: quay.io/sunix/asciidoctor
    alias: asciidoctor
commands:
  - name: asciidoctor README.adoc
    actions:
      - workdir: /projects/asciidoctor-che
        type: exec
        command: asciidoctor README.adoc
        component: asciidoctor
  - name: asciidoctor-pdf README.adoc
    actions:
      - workdir: /projects/asciidoctor-che
        type: exec
        command: asciidoctor-pdf README.adoc
        component: asciidoctor
  - name: asciidoctor-epub3 README.adoc
    actions:
      - workdir: /projects/asciidoctor-che
        type: exec
        command: asciidoctor-epub3 README.adoc
        component: asciidoctor
```
- open asciidoc-che/README.adoc
- `F1` -> `Asciidoc: Export document to pdf`
- Choose a location
- The PDF file has been generated



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
