### PR TITLE
chore(devfile): Add useful links to the didact guide

### DIFF
--- a/.che-didact-guide.md
+++ b/.che-didact-guide.md
@@ -15,15 +15,20 @@ Powered by [Eclipse Che](https://www.eclipse.org/che/) and [VSCode Didact](https
 
 Enjoy!
 
-## Adding or editing new plugins
-Since December 2020, populating the plugin registry is about editing the file `che-theia-plugins.yaml`.
+## Adding or editing plugins and editors
+Since December 2020, populating the plugin registry is about editing the file `che-theia-plugins.yaml`. Editors could be customized from the file `che-editors.yaml`.
 
 - [Open che-theia-plugins.yaml](didact://?commandId=vscode.open&projectFilePath=che-plugin-registry%2Fche-theia-plugins.yaml&number=2)
+- [Open che-editors.yaml](didact://?commandId=vscode.open&projectFilePath=che-plugin-registry%2Fche-editors.yaml&number=2)
+
+More details on how to add plugins and editors: [Open CONTRIBUTE.md](didact://?commandId=markdown.showPreview&projectFilePath=che-plugin-registry%2FCONTRIBUTE.md)
+
 
 ## Building
 The predefined task `1. build` will start building the plugin registry. The result of the build is available in the project explorer `build` folder.
 
 - [Run the `1. build` predefined task](didact://?commandId=workbench.action.tasks.runTask&text=1.%20build)
+- [Open the generated `build/v3/plugins/index.json`](didact://?commandId=vscode.open&projectFilePath=build%2Fv3%2Fplugins%2Findex.json&number=2)
 
 Generation could take some time, be patient :)
 


### PR DESCRIPTION
### What does this PR do?
In the didact guide of the dogfooding workspace:
- Add a link to open `che-editors.yaml`
- Add a link to open `CONTRIBUTE.md` in preview
- Add a link to open the generated `index.json`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
