### PR TITLE
Document surge.sh publishing

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -310,4 +310,4 @@ The job names are `surge(alpine)` and `surge(rhel)`. Clicking on `Details` in th
 For example, alpine build of PR 805 would be hosted at: https://pr-check-805-alpine-che-plugin-registry.surge.sh/
 
 ### Nightly
-A nightly build of the plugin registry is also hosted on [surge.sh](https://surge.sh/), and is updated every time a change is merged in the registry. You can find a link to this hosted registry [here](https://che-plugin-registry-main.surge.sh/).
+A nightly build of the plugin registry is also hosted on [surge.sh](https://surge.sh/), and is updated at every commit to the master branch. You can find a link to this hosted registry [here](https://che-plugin-registry-main.surge.sh/).

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -300,3 +300,14 @@ One PR can modify/add/remove multiple sidecars, they do not need to be split up 
 
 #### PR 2: Plugin Changes
 Now that the sidecar image has been built and pushed, the second PR can make use of it. The second PR will be the one that modifies the [`che-theia-plugins.yaml`](./che-theia-plugins.yaml) file.
+
+## Registry Publishing
+### Pull Requests
+All PRs in the plugin registry are published to [surge.sh](https://surge.sh/), for ease of testing. This means that a CI job will automatically build the plugin registry with a PR's changes, and publish it. The resulting link can then be used to test the PR inside Che, without needing to create a `meta.yaml` file.
+
+The job names are `surge(alpine)` and `surge(rhel)`. Clicking on `Details` in the GitHub PR view will take you to the surge.sh link. Alternatively, you can look at the link directly, which is in the following format: `https://pr-check-<PR_NUMBER>-<alpine|rhel>-che-plugin-registry.surge.sh/`
+
+For example, alpine build of PR 805 would be hosted at: https://pr-check-805-alpine-che-plugin-registry.surge.sh/
+
+### Nightly
+A nightly build of the plugin registry is also hosted on [surge.sh](https://surge.sh/), and is updated every time a change is merged in the registry. You can find a link to this hosted registry [here](https://che-plugin-registry-main.surge.sh/).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-[![CircleCI](https://circleci.com/gh/eclipse/che-plugin-registry.svg?style=svg)](https://circleci.com/gh/eclipse/che-plugin-registry)
-[![Master Build Status](https://ci.centos.org/buildStatus/icon?subject=master&job=devtools-che-plugin-registry-build-master/)](https://ci.centos.org/job/devtools-che-plugin-registry-build-master/)
-[![Nightly Build Status](https://ci.centos.org/buildStatus/icon?subject=nightly&job=devtools-che-plugin-registry-nightly/)](https://ci.centos.org/job/devtools-che-plugin-registry-nightly/)
-[![Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release&job=devtools-che-plugin-registry-release/)](https://ci.centos.org/job/devtools-che-plugin-registry-release/)
-[![Release Preview Build Status](https://ci.centos.org/buildStatus/icon?subject=release-preview&job=devtools-che-plugin-registry-release-preview/)](https://ci.centos.org/job/devtools-che-plugin-registry-release-preview/)
+# Eclipse Che Plugin Registry
 
-# Eclipse Che plugin registry
-
-This repository holds ready-to-use plugins for different languages and technologies.
+This repository holds ready-to-use plugins for different languages and technologies. A [nightly build](https://che-plugin-registry-main.surge.sh/) of this registry is published on surge.sh.
 
 ## Building and publishing third party VSIX extensions for plugin registry
 See: https://github.com/redhat-developer/codeready-workspaces/blob/master/devdoc/building/build-vsix-extension.adoc


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Documents our publishing of the plugin registry on surge.sh for both nightly and PR builds.

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
Fixes eclipse/che#18731
Fixes eclipse/che#18510

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Observe and behold, the updated README and CONTRIBUTE files.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
