### PR TITLE
Add home volume mount for che-theia editor

### DIFF
--- a/.github/workflows/happy-path.yaml
+++ b/.github/workflows/happy-path.yaml
@@ -14,11 +14,11 @@ name: Happy Path
 on:
   pull_request:
     paths:
-      - '.github/workflows/happy-path.yaml'
+      - '**/*'
       - '!sidecars/**'
   push:
     paths:
-      - '.github/workflows/happy-path.yaml'
+      - '**/*'
       - '!sidecars/**'
 
 jobs:

--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -178,7 +178,7 @@ editors:
         volumeMounts:
           - name: plugins
             path: "/plugins"
-          - name: home
+          - name: theia-local
             path: "/home/theia/.theia"
         mountSources: true
         ports:

--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -77,7 +77,7 @@ editors:
         volumeMounts:
           - name: plugins
             path: "/plugins"
-          - name: home
+          - name: theia-local
             path: "/home/theia/.theia"
         mountSources: true
         ports:

--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -77,6 +77,8 @@ editors:
         volumeMounts:
           - name: plugins
             path: "/plugins"
+          - name: home
+            path: "/home/theia/.theia"
         mountSources: true
         ports:
           - exposedPort: 3100
@@ -176,6 +178,8 @@ editors:
         volumeMounts:
           - name: plugins
             path: "/plugins"
+          - name: home
+            path: "/home/theia/.theia"
         mountSources: true
         ports:
           - exposedPort: 3100


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add home folder volume mount for che-theia editor. The GitHub authentication session is saved in this directory, so the GitHub authentication will be restored after workspace restart.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/18782

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Open the che-theia's editor `meta.yaml` (< plugin registry url >/v3/plugins/eclipse/che-theia/next/) and see the workspace storage volume mount:
```
      volumes:
        - name: plugins
          mountPath: /plugins
        - name: home
          mountPath: /home/theia/.theia
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
