### PR TITLE
fix(ruby): Fix ruby plugin setting default settings to be used

### DIFF
--- a/sidecars/ruby/Dockerfile
+++ b/sidecars/ruby/Dockerfile
@@ -13,6 +13,10 @@ FROM ruby:2.7.2-buster
 
 ENV HOME=/home/theia
 
+RUN apt-get update && \
+    apt-get install jq -y && \
+    apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir /projects ${HOME} && \
     # Change permissions to let any arbitrary user
     for f in "${HOME}" "/etc/passwd" "/projects"; do \

--- a/sidecars/ruby/etc/entrypoint.sh
+++ b/sidecars/ruby/etc/entrypoint.sh
@@ -28,4 +28,10 @@ if [ "${USER_ID}" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /
     sudo chown "${USER_ID}:${GROUP_ID}" /projects
 fi
 
+echo 'Setting "solargraph.bundlerPath" to "/usr/local/bin/bundle" and  "solargraph.commandPath" to "/usr/local/bundle/bin/solargraph"'
+mkdir -p "${CHE_PROJECTS_ROOT}"/.theia ;
+[ ! -f "${CHE_PROJECTS_ROOT}/.theia/settings.json" ] && echo "{}" > "${CHE_PROJECTS_ROOT}/.theia/settings.json"
+jq '. += {"solargraph.bundlerPath":"/usr/local/bin/bundle"}' "${CHE_PROJECTS_ROOT}/.theia/settings.json" > /tmp/temp.json && mv /tmp/temp.json "${CHE_PROJECTS_ROOT}/.theia/settings.json"
+jq '. += {"solargraph.commandPath":"/usr/local/bundle/bin/solargraph"}' "${CHE_PROJECTS_ROOT}/.theia/settings.json" > /tmp/temp.json && mv /tmp/temp.json "${CHE_PROJECTS_ROOT}/.theia/settings.json"
+
 exec "$@"


### PR DESCRIPTION
Signed-off-by: Sun Seng David TAN <sutan@redhat.com>

### What does this PR do?
Fixing settings needed for ruby plugin to work.
Using hack as mentioned in https://github.com/eclipse/che/issues/17975#issuecomment-759481640

Settings needed: https://github.com/eclipse/che/issues/18871#issuecomment-766375376

### Screenshot/screencast of this PR

![Selection_177](https://user-images.githubusercontent.com/650571/105636416-9edfaa00-5e68-11eb-8990-bc352c0386f1.png)


### What issues does this PR fix or reference?
Fix https://github.com/eclipse/che/issues/18871

### How to test this PR?
1. Start this devfile:
```yaml
apiVersion: 1.0.0
metadata:
  generateName: ruby-test-fix-settings-
projects:
  - name: rails-mister-cocktail
    source:
      type: github
      location: https://github.com/omontigny/rails-mister-cocktail
components:
  - id: castwide/solargraph/latest
    type: chePlugin
    registryUrl: 'https://sunix-che-plugin-registry-fix-ruby-yjb3d.surge.sh/v3'
```
2. edit any `.rb` file
3. see code completion is working


the provided registry refers to this manually built image which contains the changes: https://quay.io/repository/sunix/che-plugin-sidecar/manifest/sha256:bf376396c578cbd30877172abf3cc02dfeea58afa1403d44f4c2d2c7aeefd3d3

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
