### PR TITLE
chore(build-check): Add check script to verify that docker images used in registry are valid

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -39,6 +39,7 @@ RUN ./check_metas_schema.sh v3
 RUN if [[ ${USE_DIGESTS} == "true" ]]; then ./write_image_digests.sh v3;fi
 RUN ./index.sh v3 > /build/v3/plugins/index.json
 RUN ./list_referenced_images.sh v3 > /build/v3/external_images.txt
+RUN ./check_referenced_images.sh < /build/v3/external_images.txt
 RUN chmod -R g+rwX /build
 
 # Build registry, copying meta.yamls and index.json from builder

--- a/build/scripts/check_referenced_images.sh
+++ b/build/scripts/check_referenced_images.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright (c) 2019-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+# Check with skopeo that images are valid. Image list should be passed through stdin.
+set -e
+
+while read -r extenal_image
+do  
+  echo "Checking that $extenal_image is a valid image";
+  skopeo inspect "docker://$extenal_image" >/dev/null;
+  echo "... OK";
+done


### PR DESCRIPTION
Signed-off-by: Sun Tan <sutan@redhat.com>

### What does this PR do?
Check that each images used in the registry are valid

### Screenshot/screencast of this PR
![Selection_179](https://user-images.githubusercontent.com/650571/105746862-45e34500-5f40-11eb-9b68-9b0d48ec59d9.png)

Failing:
![Selection_180](https://user-images.githubusercontent.com/650571/105746901-55fb2480-5f40-11eb-8277-75397bef291d.png)




### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Fix https://github.com/eclipse/che/issues/18747

### How to test this PR?
- Clone the repo and checkout the branch of this PR
- build the registry image
- check that it is working fine
- change https://github.com/eclipse/che-plugin-registry/blob/835b5318669141b43c6ca2013224d69fac6000cd/che-theia-plugins.yaml#L320, replacing `quay.io/windupeng/mta-vscode-extension:latest` with `quay.io/windupeng/mta-vscode-extension:wrongtag`
- restart the build and see that it is failing

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
