### PR TITLE
Add a PR check to ensure that sidecar executable files have executable permissions

### DIFF
--- a/.ci/sidecar-check-script-permissions.sh
+++ b/.ci/sidecar-check-script-permissions.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+set -e
+
+# shellcheck disable=SC2207
+FILES_CHANGED=($(git diff --name-only -r "$1" "$2" -- "sidecars/*.sh"))
+NON_EXECUTABLE_SCRIPTS=()
+
+for file in "${FILES_CHANGED[@]}"
+do
+    if ! [[ -x "$file" ]]; then
+        echo "ERROR: $file is not executable"
+        NON_EXECUTABLE_SCRIPTS+=("$file")
+    fi
+done
+
+# shellcheck disable=SC2199
+if [[ "${NON_EXECUTABLE_SCRIPTS[@]}" ]]; then
+    exit 1
+fi

--- a/.github/workflows/sidecar-scripts-executable-pr-check.yaml
+++ b/.github/workflows/sidecar-scripts-executable-pr-check.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: Sidecar scripts PR check
+
+on:
+  pull_request:
+    paths:
+    - 'sidecars/**'
+
+jobs:
+  executable-permissions-pr-check:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Clone source code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Check .sh files inside sidecars folder
+      run: |
+        ./.ci/sidecar-check-script-permissions.sh origin/${{ github.base_ref }} ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
If a sidecar adds any .sh files, check that they are executable to prevent entrypoint errors.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

Fixes eclipse/che#18737

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

Locally, add a non-executable .sh file in `sidecars/*` and run `.ci/sidecar-check-script-permissions.sh`. The script should fail until the file gets executable permissions.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
