### PR TITLE
feat(digest): Do not use digest on next or nightly tags

### DIFF
--- a/tools/build/src/registry/registry-helper.ts
+++ b/tools/build/src/registry/registry-helper.ts
@@ -26,6 +26,11 @@ export class RegistryHelper {
     // grab image name and tag
     const dockerImageName = parse(imageName);
 
+    // do not use digest on nightlies/next
+    if (dockerImageName.tag === 'nightly' || dockerImageName.tag === 'next') {
+      return imageName;
+    }
+
     const uri = `https://${dockerImageName.host}/v2/${dockerImageName.remoteName}/manifests/${dockerImageName.tag}`;
 
     // if registry is [index.]docker.io, need to grab a token first

--- a/tools/build/tests/registry/registry-helper.spec.ts
+++ b/tools/build/tests/registry/registry-helper.spec.ts
@@ -110,4 +110,14 @@ describe('Test RegistryHelper', () => {
     // image should have library as prefix as well and index.docker.io as host
     expect(digest).toBe(`index.docker.io/library/alpine@sha256:${hash}`);
   });
+
+  test('basics with next', async () => {
+    const axiosGet = jest.spyOn(Axios, 'get') as jest.Mock;
+    const imageName = 'fake-docker-registry.com/dummy-org/dummy-image:next';
+    const axiosHead = jest.spyOn(Axios, 'head') as jest.Mock;
+    const updatedImageName = await registryHelper.getImageDigest('fake-docker-registry.com/dummy-org/dummy-image:next');
+    expect(updatedImageName).toBe(imageName);
+    expect(axiosGet).toBeCalledTimes(0);
+    expect(axiosHead).toBeCalledTimes(0);
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Digests should be used on 'static' tags not on 'on purpose floating tags' so as soon as next images are updated they're used


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18931

### How to test this PR?
check that in external_images.txt file or in che-theia and machine-exec, the digests are not used for next and nightly tag


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: I53c0be81b4f063306a809f54fdb60ec64349c94e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
