### PR TITLE
Decrease cpu limits to allow run a workspace on minikube with default cpu configuration

### DIFF
--- a/che-editors.yaml
+++ b/che-editors.yaml
@@ -87,8 +87,8 @@ editors:
           - exposedPort: 13132
           - exposedPort: 13133
         memoryLimit: "512M"
-        cpuLimit: 1500m
-        cpuRequest: 500m
+        cpuLimit: 1000m
+        cpuRequest: 100m
     initContainers:
       - name: remote-runtime-injector
         image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:next"


### PR DESCRIPTION
### What does this PR do?
This change proposal lowers the value for the cpuLimit and cpuRequest to allow workspace to run on minikube, which is run with default CPU configuration. By default the value for the CPU is set to 2. After merging the following PR, the general cpuRequest value is more than minikube is available to provide for normal workspace startup. The new values for the cpuLimit is set from 1.5 to 1 and for the cpuRequest is set from 0.5 to 0.1.

Tested on OSIO, RHPDS, Dogfooding and minikube.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/18955


### How to test this PR?
Start minikube with the following configuration:
```
$ minikube start --addons=ingress --vm=true --memory=8192
```
Deploy Che:
```
$ chectl update next && \
  chectl server:deploy -p minikube
```

Create the workspace from the following devfile:

<details>
  <summary>devfile</summary>
  
```yaml
apiVersion: 1.0.0
metadata:
  name: java-mysql
projects:
  - name: web-java-spring-petclinic
    source:
      location: 'https://github.com/spring-projects/spring-petclinic.git'
      type: git
      branch: main
components:
  - type: cheEditor
    reference: 'https://gist.github.com/vzhukovs/732676571880f51bc0b87cc2f7ee1304/raw/12706cb543c5572ceb736fffaf143de909a281e7/meta.yaml'
  - type: chePlugin
    reference: 'https://gist.github.com/vzhukovs/071cc61b3c2d170392c41aee98178c16/raw/cb47e2af2006ecfedb7ef45b00ffa72507f09072/meta.yaml'
    alias: exec
  - memoryLimit: 1280Mi
    type: chePlugin
    reference: 'https://gist.github.com/vzhukovs/d375a1ee62df950a9d98fffe5d15c25b/raw/f18e93f2293c3d8e5d85e80d8affa18d4a34c776/meta.yaml'
    alias: java
  - mountSources: true
    endpoints:
      - name: 8080-tcp
        port: 8080
      - attributes:
          public: 'false'
        name: debug
        port: 5005
    memoryLimit: 1000Mi
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    alias: tools
    image: 'quay.io/eclipse/che-java8-maven:nightly'
    env:
      - value: ''
        name: MAVEN_CONFIG
      - value: '-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user'
        name: JAVA_OPTS
      - value: $(JAVA_OPTS)
        name: MAVEN_OPTS
  - mountSources: true
    endpoints:
      - attributes:
          discoverable: 'true'
          public: 'false'
        name: db
        port: 3306
    memoryLimit: 300Mi
    type: dockerimage
    alias: mysql
    image: 'quay.io/eclipse/che--centos--mysql-57-centos7:latest-e08ee4d43b7356607685b69bde6335e27cf20c020f345b6c6c59400183882764'
    env:
      - value: petclinic
        name: MYSQL_USER
      - value: petclinic
        name: MYSQL_PASSWORD
      - value: petclinic
        name: MYSQL_DATABASE
      - value: '$(echo ${0})\\$'
        name: PS1
commands:
  - name: maven build
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/web-java-spring-petclinic'
        type: exec
        command: mvn clean install
        component: tools
  - name: run webapp
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/web-java-spring-petclinic'
        type: exec
        command: |
          SPRING_DATASOURCE_URL=jdbc:mysql://db/petclinic \
          SPRING_DATASOURCE_USERNAME=petclinic \
          SPRING_DATASOURCE_PASSWORD=petclinic \
          java -jar -Dspring.profiles.active=mysql \
          -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 \
          target/*.jar
        component: tools
  - name: prepare database
    actions:
      - type: exec
        command: |
          /opt/rh/rh-mysql57/root/usr/bin/mysql -u root < ${CHE_PROJECTS_ROOT}/web-java-spring-petclinic/src/main/resources/db/mysql/user.sql &&
          /opt/rh/rh-mysql57/root/usr/bin/mysql -u root petclinic < ${CHE_PROJECTS_ROOT}/web-java-spring-petclinic/src/main/resources/db/mysql/schema.sql &&
          echo -e "\e[32mDone.\e[0m Database petclinic was configured!"
        component: mysql
  - name: Debug remote java application
    actions:
      - referenceContent: |
          {
          "version": "0.2.0",
          "configurations": [
            {
              "type": "java",
              "name": "Debug (Attach) - Remote",
              "request": "attach",
              "hostName": "localhost",
              "port": 5005
            }]
          }
        type: vscode-launch

```
</details>

Workspace should be able to start and do not show the error message:
```
0/1 nodes are available: 1 Insufficient cpu.
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
