### PR TITLE
Add init v4 plugins based on devfile v2

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -25,5 +25,6 @@ COPY README.md .htaccess /usr/local/apache2/htdocs/
 COPY output/v3 /usr/local/apache2/htdocs/v3
 COPY v3/plugins/.htaccess /usr/local/apache2/htdocs/v3/plugins/
 COPY v3/images/eclipse-che-logo.png /usr/local/apache2/htdocs/v3/images/
+COPY v4 /usr/local/apache2/htdocs/v4/
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 CMD ["httpd-foreground"]

--- a/v4/.htaccess
+++ b/v4/.htaccess
@@ -1,0 +1,1 @@
+DirectoryIndex devfile.yaml index.json

--- a/v4/plugins/eclipse/che-machine-exec/nightly/devfile.yaml
+++ b/v4/plugins/eclipse/che-machine-exec/nightly/devfile.yaml
@@ -1,0 +1,25 @@
+schemaVersion: "2.0.0"
+metadata:
+  name: "Che Machine Exec"
+components:
+- name: terminal
+  attributes:
+    "app.kubernetes.io/name": che-terminal.eclipse.org
+    "app.kubernetes.io/part-of": che.eclipse.org
+    "app.kubernetes.io/component": terminal
+  container:
+    image: "quay.io/eclipse/che-machine-exec:nightly"
+    command: ['/go/bin/che-machine-exec']
+    args:
+      - '--url'
+      - '0.0.0.0:4444'
+      - '--pod-selector'
+      - controller.devfile.io/workspace_id=$(DEVWORKSPACE_ID)
+    endpoints:
+      - name: "che-mach-exec"
+        exposure: public
+        targetPort: 4444
+        protocol: ws
+        secure: false
+        attributes:
+          type: terminal

--- a/v4/plugins/eclipse/che-machine-exec/nightly/devfile.yaml
+++ b/v4/plugins/eclipse/che-machine-exec/nightly/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "2.0.0"
+schemaVersion: "2.1.0"
 metadata:
   name: "Che Machine Exec"
 components:

--- a/v4/plugins/eclipse/che-theia/next/devfile.yaml
+++ b/v4/plugins/eclipse/che-theia/next/devfile.yaml
@@ -1,0 +1,80 @@
+schemaVersion: "2.0.0"
+metadata:
+  name: "Che Theia"
+components:
+- name: remote-runtime-injector
+  attributes:
+    "app.kubernetes.io/part-of": che-theia.eclipse.org
+    "app.kubernetes.io/component": bootstrapper
+  container:
+    image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0"
+    volumeMounts:
+      - path: "/remote-endpoint"
+        name: remote-endpoint
+    env:
+      - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+        value: /remote-endpoint/plugin-remote-endpoint
+      - name: REMOTE_ENDPOINT_VOLUME_NAME
+        value: remote-endpoint
+- name: theia-ide
+  attributes:
+    "app.kubernetes.io/name": che-theia.eclipse.org
+    "app.kubernetes.io/part-of": che.eclipse.org
+    "app.kubernetes.io/component": editor
+  container:
+    image: "quay.io/eclipse/che-theia:next"
+    env:
+      - name: THEIA_PLUGINS
+        value: local-dir:///plugins
+      - name: HOSTED_PLUGIN_HOSTNAME
+        value: 0.0.0.0
+      - name: HOSTED_PLUGIN_PORT
+        value: "3130"
+      - name: THEIA_HOST
+        value: 0.0.0.0
+    volumeMounts:
+      - path: "/plugins"
+        name: plugins
+    mountSources: true
+    memoryLimit: "512M"
+    endpoints:
+      - name: "theia"
+        exposure: public
+        targetPort: 3100
+        secure: false
+        protocol: http
+        attributes:
+          type: ide
+      - name: "webviews"
+        exposure: public
+        targetPort: 3100
+        protocol: http
+        secure: false
+        attributes:
+          type: webview
+          unique: "true"
+      - name: "theia-dev"
+        exposure: public
+        targetPort: 3130
+        protocol: http
+        attributes:
+          type: ide-dev
+      - name: "theia-redir-1"
+        exposure: public
+        targetPort: 13131
+        protocol: http
+      - name: "theia-redir-2"
+        exposure: public
+        targetPort: 13132
+        protocol: http
+      - name: "theia-redir-3"
+        exposure: public
+        targetPort: 13133
+        protocol: http
+commands:
+- id: inject-theia-in-remote-sidecar
+  apply:
+    component: remote-runtime-injector
+events:
+  preStart:
+    - inject-theia-in-remote-sidecar

--- a/v4/plugins/eclipse/che-theia/next/devfile.yaml
+++ b/v4/plugins/eclipse/che-theia/next/devfile.yaml
@@ -71,6 +71,10 @@ components:
         exposure: public
         targetPort: 13133
         protocol: http
+- name: plugins
+  volume: {}
+- name: remote-endpoint
+  volume: {}
 commands:
 - id: inject-theia-in-remote-sidecar
   apply:

--- a/v4/plugins/eclipse/che-theia/next/devfile.yaml
+++ b/v4/plugins/eclipse/che-theia/next/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "2.0.0"
+schemaVersion: "2.1.0"
 metadata:
   name: "Che Theia"
 components:
@@ -36,7 +36,9 @@ components:
       - path: "/plugins"
         name: plugins
     mountSources: true
-    memoryLimit: "512M"
+    memoryLimit: 512M
+    cpuLimit: 1500m
+    cpuRequest: 100m
     endpoints:
       - name: "theia"
         exposure: public

--- a/v4/plugins/index.json
+++ b/v4/plugins/index.json
@@ -1,0 +1,26 @@
+[
+    {
+        "id": "eclipse/che-theia/next",
+        "description": "Eclipse Theia",
+        "displayName": "theia-ide",
+        "links": {
+            "self": "/v4/plugins/eclipse/che-theia/next"
+        },
+        "name": "che-theia",
+        "publisher": "eclipse",
+        "type": "Che Editor",
+        "version": "latest"
+    },
+    {
+        "id": "eclipse/che-machine-exe/nightly",
+        "description": "Che Plug-in with che-machine-exec service to provide creation terminal or tasks for Eclipse Che workspace containers.",
+        "displayName": "Che machine-exec Service",
+        "links": {
+            "self": "/v4/plugins/eclipse/che-machine-exec/nightly"
+        },
+        "name": "che-machine-exec-plugin",
+        "publisher": "eclipse",
+        "type": "Che Plugin",
+        "version": "nightly"
+    }
+]


### PR DESCRIPTION
### What does this PR do?
This PR add init v4 for plugins based on devfile v2, it's just Che Theia and machine exec extracted from https://github.com/devfile/devworkspace-operator/blob/master/samples/flattened_theia-next.yaml

Tested API:
<details>
<summary>https://plugin-registry-eclipse-che.192.168.39.241.nip.io/v4/plugins/index.json</summary>

```json
[
  {
    "id": "eclipse/che-theia/next",
    "description": "Eclipse Theia",
    "displayName": "theia-ide",
    "links": {
      "self": "/v4/plugins/eclipse/che-theia/next"
    },
    "name": "che-theia",
    "publisher": "eclipse",
    "type": "Che Editor",
    "version": "latest"
  },
  {
    "id": "eclipse/che-machine-exe/nightly",
    "description": "Che Plug-in with che-machine-exec service to provide creation terminal or tasks for Eclipse Che workspace containers.",
    "displayName": "Che machine-exec Service",
    "links": {
      "self": "/v4/plugins/eclipse/che-machine-exec/nightly"
    },
    "name": "che-machine-exec-plugin",
    "publisher": "eclipse",
    "type": "Che Plugin",
    "version": "nightly"
  }
]
```

</details>

<details>
<summary>https://plugin-registry-eclipse-che.192.168.39.241.nip.io/v4/plugins/eclipse/che-machine-exec/nightly/</summary>

```yaml
schemaVersion: "2.0.0"
metadata:
  name: "Che Machine Exec"
components:
- name: terminal
  attributes:
    "app.kubernetes.io/name": che-terminal.eclipse.org
    "app.kubernetes.io/part-of": che.eclipse.org
    "app.kubernetes.io/component": terminal
  container:
    image: "quay.io/eclipse/che-machine-exec:nightly"
    command: ['/go/bin/che-machine-exec']
    args:
      - '--url'
      - '0.0.0.0:4444'
      - '--pod-selector'
      - controller.devfile.io/workspace_id=$(DEVWORKSPACE_ID)
    endpoints:
      - name: "che-mach-exec"
        exposure: public
        targetPort: 4444
        protocol: ws
        secure: false
        attributes:
          type: terminal
```

</details>

### What issues does this PR fix or reference?
It's done as a first step of https://github.com/eclipse/che/issues/19034


### How to test this PR?
You use `quay.io/sleshche/che-plugin-registry:v4` to test v4.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
