### PR TITLE
Hotfix for `7.26.0` rollout of Hosted Che

### DIFF
--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -24,8 +24,6 @@ function load_jenkins_vars() {
             QUAY_PASSWORD \
             QUAY_ECLIPSE_CHE_USERNAME \
             QUAY_ECLIPSE_CHE_PASSWORD \
-            RH_CHE_AUTOMATION_DOCKERHUB_USERNAME \
-            RH_CHE_AUTOMATION_DOCKERHUB_PASSWORD \
             JENKINS_URL \
             GIT_BRANCH \
             GIT_COMMIT \
@@ -97,12 +95,6 @@ function build_and_push() {
     docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" "${REGISTRY}"
   else
     echo "Could not login, missing credentials for pushing to the '${ORGANIZATION}' organization"
-  fi
-
-  if [ -n "${RH_CHE_AUTOMATION_DOCKERHUB_USERNAME}" ] && [ -n "${RH_CHE_AUTOMATION_DOCKERHUB_PASSWORD}" ]; then
-    docker login -u "${RH_CHE_AUTOMATION_DOCKERHUB_USERNAME}" -p "${RH_CHE_AUTOMATION_DOCKERHUB_PASSWORD}"
-  else
-    echo "Could not login, missing credentials for pushing to the docker.io"
   fi
 
   # Let's build and push image to 'quay.io' using git commit hash as tag first

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -82,10 +82,12 @@ function build_and_push() {
     DOCKERFILE="rhel.Dockerfile"
     ORGANIZATION="openshiftio"
     IMAGE="rhel-che-plugin-registry"
+    UPSTREAM_IMAGE="quay.io/eclipse/che-plugin-registry:7.26.0-rhel"
   else
     DOCKERFILE="Dockerfile"
     ORGANIZATION="eclipse"
     IMAGE="che-plugin-registry"
+    UPSTREAM_IMAGE="quay.io/eclipse/che-plugin-registry:7.26.0"
     # For pushing to quay.io 'eclipse' organization we need to use different credentials
     QUAY_USERNAME=${QUAY_ECLIPSE_CHE_USERNAME}
     QUAY_PASSWORD=${QUAY_ECLIPSE_CHE_PASSWORD}
@@ -99,7 +101,9 @@ function build_and_push() {
 
   # Let's build and push image to 'quay.io' using git commit hash as tag first
   set_git_commit_tag
-  docker build -t ${IMAGE} -f ./build/dockerfiles/${DOCKERFILE} --target registry . | cat
+  docker pull ${UPSTREAM_IMAGE}
+  docker tag ${UPSTREAM_IMAGE} ${REGISTRY}/${ORGANIZATION}/${IMAGE}:${GIT_COMMIT_TAG}
+
   tag_push "${REGISTRY}/${ORGANIZATION}/${IMAGE}:${GIT_COMMIT_TAG}"
   echo "CICO: '${GIT_COMMIT_TAG}' version of images pushed to '${REGISTRY}/${ORGANIZATION}' organization"
 


### PR DESCRIPTION
Hotfix for `7.26.0` rollout of Hosted Che - https://ci.centos.org/job/devtools-che-plugin-registry-release-preview/
This is planned to be the last rollout update