### PR TITLE
chore(build): Do not build plugin-registry image PR check when only sidecar files are modified

### DIFF
--- a/.github/workflows/image-build-pr-check.yml
+++ b/.github/workflows/image-build-pr-check.yml
@@ -9,7 +9,15 @@
 
 name: Image Build PR check
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - '**/*'
+      - '!sidecars/**'
+  push:
+    paths:
+      - '**/*'
+      - '!sidecars/**'
 
 jobs:
   image-build:


### PR DESCRIPTION
### What does this PR do?
Do not build image if modified files are in sidecar/** folder.
So it won't try to fetch images that are not yet published

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che-plugin-registry/pull/849#issuecomment-783696324

### How to test this PR?
this workflow should only happen if we do not modify sidecar folder


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: I09a09849c885256e1fba2c5c3c2f2632edd2e4f0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
