### PR TITLE
feat(lombok): making lombok.jar available to java sidecar

### DIFF
--- a/sidecars/java/Dockerfile
+++ b/sidecars/java/Dockerfile
@@ -11,6 +11,7 @@
 FROM alpine:3.12.1
 
 ENV HOME=/home/theia
+ENV LOMBOK_VERSION=1.18.18
 
 RUN mkdir /projects ${HOME} && \
     # Change permissions to let any arbitrary user
@@ -23,6 +24,8 @@ RUN apk --no-cache add openjdk11 --repository=http://dl-cdn.alpinelinux.org/alpi
     && apk add procps nss
 ENV JAVA_HOME /usr/lib/jvm/default-jvm/
 ADD etc/before-start.sh /before-start.sh
+
+RUN wget -O ${HOME}/lombok.jar https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
 
 WORKDIR /projects
 

--- a/sidecars/java8/Dockerfile
+++ b/sidecars/java8/Dockerfile
@@ -11,6 +11,7 @@
 FROM alpine:3.10.2
 
 ENV HOME=/home/theia
+ENV LOMBOK_VERSION=1.18.18
 
 RUN mkdir /projects ${HOME} && \
     # Change permissions to let any arbitrary user
@@ -24,6 +25,8 @@ ENV JAVA_HOME /usr/lib/jvm/default-jvm/
 ADD etc/before-start.sh /before-start.sh
 
 ADD etc/entrypoint.sh /entrypoint.sh
+
+RUN wget -O ${HOME}/lombok.jar https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
 
 WORKDIR /projects
 


### PR DESCRIPTION
### What does this PR do?
Making the lombok.jar available to Java.
So user would just need to configure in the devfile:
```
  - id: redhat/java/latest
    type: chePlugin
    preferences:
      java.jdt.ls.vmargs: -javaagent:/home/theia/lombok.jar
```

### Screenshot/screencast of this PR
![Selection_249](https://user-images.githubusercontent.com/650571/109039818-81069e80-76cd-11eb-83f1-bb162ea99f55.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17483

<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
Use this devfile: it is using a custom registry that has the java plugin patched to use the image of the sidecar i have built locally.
1. start a workspace with the following devfile
2. open one of the java file `ModelLombokValue.java`, wait for java plugin to be activated
3. open the outline, see the getters and setters that are not defined in the class.


```yaml
apiVersion: 1.0.0
metadata:
  generateName: java-lombok-
projects:
  - name: lombok-project-example
    source:
      location: 'https://github.com/chuucks/LOMBOK-PROJECT-EXAMPLE'
      type: git
      branch: master

components:

  - type: chePlugin
    id: redhat/java/latest
    preferences:
      java.server.launchMode: Standard
      java.jdt.ls.vmargs: -javaagent:/home/theia/lombok.jar
    registryUrl: https://sunix-plugin-registry-java-lombok-agher.surge.sh/v3

  - mountSources: true
    endpoints:
      - name: debug
        port: 5005
        attributes:
          public: 'false'
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    image: 'quay.io/eclipse/che-java11-maven:7.22.1'
    alias: maven
    env:
      - value: ''
        name: MAVEN_CONFIG
      - value: >-
          -XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
          -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true
          -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user
        name: MAVEN_OPTS
      - value: >-
          -XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
          -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true
          -Xms20m -Djava.security.egd=file:/dev/./urandom
        name: JAVA_OPTS
      - value: >-
          -XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
          -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true
          -Xms20m -Djava.security.egd=file:/dev/./urandom
        name: JAVA_TOOL_OPTIONS

commands:
  - name: maven build
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/lombok-project-example'
        type: exec
        command: mvn clean install
        component: maven
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
