### PR TITLE
fix(java-sidecar): Moving lombok.jar to a generic location

### DIFF
--- a/sidecars/java/Dockerfile
+++ b/sidecars/java/Dockerfile
@@ -25,7 +25,7 @@ RUN apk --no-cache add openjdk11 --repository=http://dl-cdn.alpinelinux.org/alpi
 ENV JAVA_HOME /usr/lib/jvm/default-jvm/
 ADD etc/before-start.sh /before-start.sh
 
-RUN wget -O ${HOME}/lombok.jar https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
+RUN wget -O /lombok.jar https://projectlombok.org/downloads/lombok-${LOMBOK_VERSION}.jar
 
 WORKDIR /projects
 


### PR DESCRIPTION
### What does this PR do?
Moving lombok.jar to a more generic location: `/lombok.jar` instead of `/home/theia/lombok.jar`.

$HOME env variable could not be used when settings lombok location in 
```yaml
  - id: redhat/java/latest
    preferences:
      java.jdt.ls.vmargs: '-javaagent:${HOME}/lombok.jar'
```
With this PR:

```yaml
  - id: redhat/java/latest
    preferences:
      java.jdt.ls.vmargs: '-javaagent:/lombok.jar'
```

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17483


### How to test this PR?
with this devfile:
```yaml
apiVersion: 1.0.0
metadata:
  generateName: java-lombok-
projects:
  - name: lombok-project-example
    source:
      location: 'https://github.com/chuucks/LOMBOK-PROJECT-EXAMPLE'
      type: git
      branch: master
components:
  - id: redhat/java/latest
    preferences:
      java.jdt.ls.vmargs: '-javaagent:/lombok.jar'
      java.server.launchMode: Standard
    registryUrl: 'https://sunix-plugin-registry-lombok-location-esc6v.surge.sh/v3'
    type: chePlugin
  - mountSources: true
    endpoints:
      - attributes:
          public: 'false'
        name: debug
        port: 5005
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    image: 'quay.io/eclipse/che-java11-maven:7.22.1'
    alias: maven
    env:
      - value: ''
        name: MAVEN_CONFIG
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user'
        name: MAVEN_OPTS
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom'
        name: JAVA_OPTS
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom'
        name: JAVA_TOOL_OPTIONS
commands:
  - name: maven build
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/lombok-project-example'
        type: exec
        command: mvn clean install
        component: maven

```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
