### PR TITLE
feat(devfile2): Use secure:false + s on protocol for secured devfile2 items

### DIFF
--- a/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
+++ b/tools/build/src/devfile/meta-yaml-to-devfile-yaml.ts
@@ -112,10 +112,14 @@ export class MetaYamlToDevfileYaml {
           devfileEndpoint.exposure = 'public';
         }
 
-        // if it's secured, remove secure option for now
+        // if it's secured, remove secure option for now but add extra s on the protocol
         if (devfileEndpoint.attributes && devfileEndpoint.attributes.secure === true) {
           devfileEndpoint.secure = false;
           delete devfileEndpoint.attributes['secure'];
+          // add extra s
+          if (devfileEndpoint.attributes.protocol) {
+            devfileEndpoint.attributes.protocol = `${devfileEndpoint.attributes.protocol}s`;
+          }
         }
 
         // move protocol upper than inside attributes

--- a/tools/build/tests/_data/meta/machine-exec-plugin-meta.yaml
+++ b/tools/build/tests/_data/meta/machine-exec-plugin-meta.yaml
@@ -22,6 +22,14 @@ spec:
         discoverable: false
         secure: true
         cookiesAuthEnabled: true
+    - name: dummy
+      public: true
+      targetPort: 4444
+      attributes:
+        type: terminal
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
   containers:
     - name: che-machine-exec
       image: 'quay.io/eclipse/che-machine-exec:nightly'

--- a/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
+++ b/tools/build/tests/devfile/meta-yaml-to-devfile-yaml.spec.ts
@@ -47,10 +47,12 @@ describe('Test MetaYamlToDevfileYaml', () => {
     expect(componentContainer.args).toStrictEqual(['/go/bin/che-machine-exec', '--url', '0.0.0.0:4444']);
 
     expect(componentContainer.endpoints).toBeDefined();
-    expect(componentContainer.endpoints?.length).toBe(1);
+    expect(componentContainer.endpoints?.length).toBe(2);
     const endpoint = componentContainer.endpoints[0];
     expect(endpoint.name).toBe('che-machine-exec');
     expect(endpoint.exposure).toBe('public');
+    expect(endpoint.secure).toBe(false);
+    expect(endpoint.protocol).toBe('wss');
     const endpointAttributes = endpoint.attributes;
     expect(endpointAttributes.type).toBe('terminal');
   });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Use secure protocol but not secured flag

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

https://github.com/eclipse/che/issues/19347

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Check generated devfile.yaml (s suffix on protocol for secure endpoints)or look at the unit test


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: Idd394f18a38da681ae55975e266a2f4374fb4309
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
