### PR TITLE
feat(preferences): Allow to define preferences in che-theia-plugins.yaml

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -30,6 +30,13 @@ Here are all the supported values, including optional ones:
     # (OPTIONAL) An alias for this plugin: this means anything listed here will get its own meta.yaml generated
     aliases:
       - redhat/java
+    # (OPTIONAL) plug-in preferences in freeform format
+    preferences:
+      # name of the preference with it's value, example:
+      asciidoc.use_asciidoctorpdf: true
+      shellcheck.executablePath: /bin/shellcheck
+      solargraph.bundlerPath: /usr/local/bin/bundle
+      solargraph.commandPath: /usr/local/bundle/bin/solargraph
     # (OPTIONAL) If the plugin runs in a sidecar, then the sidecar information is specified here
     sidecar:
       # Directory where the Dockerfile that builds this extension is located

--- a/tools/build/src/build.ts
+++ b/tools/build/src/build.ts
@@ -145,9 +145,10 @@ export class Build {
         const id = cheTheiaPluginYaml.id;
         const featured = cheTheiaPluginYaml.featured || false;
         const aliases = cheTheiaPluginYaml.aliases || [];
+        const preferences = cheTheiaPluginYaml.preferences;
         const sidecar = cheTheiaPluginYaml.sidecar;
         const repository = cheTheiaPluginYaml.repository;
-        return { id, sidecar, aliases, extensions, featured, vsixInfos, repository };
+        return { id, sidecar, preferences, aliases, extensions, featured, vsixInfos, repository };
       })
     );
 

--- a/tools/build/src/che-theia-plugin/che-theia-plugin-analyzer-meta-info.ts
+++ b/tools/build/src/che-theia-plugin/che-theia-plugin-analyzer-meta-info.ts
@@ -16,6 +16,8 @@ export interface CheTheiaPluginAnalyzerMetaInfo {
   featured: boolean;
   extensions: string[];
   aliases: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  preferences?: { [key: string]: any };
   sidecar?: CheTheiaPluginSidecarDirectoryYaml | CheTheiaPluginSidecarImageYaml;
   repository: {
     url: string;

--- a/tools/build/src/che-theia-plugin/che-theia-plugins-meta-yaml-generator.ts
+++ b/tools/build/src/che-theia-plugin/che-theia-plugins-meta-yaml-generator.ts
@@ -18,6 +18,8 @@ import { Sidecar } from '../sidecar/sidecar';
 
 @injectable()
 export class CheTheiaPluginsMetaYamlGenerator {
+  static readonly CHE_THEIA_SIDECAR_PREFERENCES = 'CHE_THEIA_SIDECAR_PREFERENCES';
+
   @inject(Sidecar)
   private sidecar: Sidecar;
 
@@ -154,6 +156,18 @@ export class CheTheiaPluginsMetaYamlGenerator {
           }
           if (chePlugin.sidecar.env) {
             container.env = chePlugin.sidecar.env;
+          }
+
+          // add preferences in env
+          if (chePlugin.preferences) {
+            if (!container.env) {
+              container.env = [];
+            }
+            // need to convert json to sringified version
+            container.env.push({
+              name: CheTheiaPluginsMetaYamlGenerator.CHE_THEIA_SIDECAR_PREFERENCES,
+              value: JSON.stringify(chePlugin.preferences),
+            });
           }
           if (chePlugin.sidecar.mountSources) {
             container.mountSources = chePlugin.sidecar.mountSources;

--- a/tools/build/src/che-theia-plugin/che-theia-plugins-yaml.ts
+++ b/tools/build/src/che-theia-plugin/che-theia-plugins-yaml.ts
@@ -38,6 +38,8 @@ export interface CheTheiaPluginYaml {
   id?: string;
   featured?: boolean;
   aliases?: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  preferences?: { [key: string]: any };
   sidecar?: CheTheiaPluginSidecarDirectoryYaml | CheTheiaPluginSidecarImageYaml;
   repository: {
     url: string;

--- a/tools/build/src/meta-yaml/meta-yaml-plugin-info.ts
+++ b/tools/build/src/meta-yaml/meta-yaml-plugin-info.ts
@@ -26,7 +26,7 @@ export interface MetaYamlPluginInfo {
   latestUpdateDate: string;
   aliases?: string[];
   spec: {
-    containers?: [{ image: string; command?: string[]; args?: string[] }];
+    containers?: [{ image: string; command?: string[]; args?: string[]; env?: { name: string; value: string }[] }];
     initContainers?: [{ image: string }];
     extensions: string[];
   };

--- a/tools/build/tests/che-plugin/che-plugin-analyzer.spec.ts
+++ b/tools/build/tests/che-plugin/che-plugin-analyzer.spec.ts
@@ -33,13 +33,13 @@ describe('Test ChePluginsAnalyzer', () => {
     const result = await chePluginsAnalyzer.analyze(testContentPath);
     expect(result).toBeDefined();
     expect(result.plugins).toBeDefined();
-    expect(result.plugins.length).toBeGreaterThan(5);
+    expect(result.plugins.length).toBeGreaterThan(4);
 
     // search for plugins with an id provided in yaml
-    const machineExecPlugins = result.plugins.filter(plugin => plugin.id === 'eclipse/che-machine-exec-plugin/nightly');
-    expect(machineExecPlugins).toBeDefined();
-    expect(machineExecPlugins.length).toBe(1);
-    const machineExecPlugin = machineExecPlugins[0];
-    expect(machineExecPlugin.repository).toBe('https://github.com/eclipse/che-machine-exec/');
+    const buildahPlugins = result.plugins.filter(plugin => plugin.id === 'containers/buildah/1.14.0');
+    expect(buildahPlugins).toBeDefined();
+    expect(buildahPlugins.length).toBe(1);
+    const buildahPlugin = buildahPlugins[0];
+    expect(buildahPlugin.repository).toBe('https://github.com/containers/buildah');
   });
 });

--- a/tools/build/tests/che-theia-plugin/che-theia-plugins-meta-yaml-generator.spec.ts
+++ b/tools/build/tests/che-theia-plugin/che-theia-plugins-meta-yaml-generator.spec.ts
@@ -49,6 +49,10 @@ describe('Test CheTheiaPluginsAnalyzer', () => {
       id: cheTheiaPluginId,
       featured: false,
       aliases: [],
+      preferences: {
+        'my.preferences1': true,
+        'debug.node.useV3': false,
+      },
       sidecar: {
         name: 'my-name',
         memoryRequest: '1m',
@@ -147,6 +151,12 @@ describe('Test CheTheiaPluginsAnalyzer', () => {
     expect(metaYamlInfoSpecContainers).toBeDefined();
     expect(metaYamlInfoSpecContainers.length).toBe(1);
     expect(metaYamlInfoSpecContainers[0].image).toBe(fakeImage);
+    const theiaPreferencesEnv = metaYamlInfoSpecContainers[0].env?.find(
+      env => env.name === CheTheiaPluginsMetaYamlGenerator.CHE_THEIA_SIDECAR_PREFERENCES
+    );
+    expect(theiaPreferencesEnv).toBeDefined();
+    expect(theiaPreferencesEnv?.value).toEqual('{"my.preferences1":true,"debug.node.useV3":false}');
+    expect(metaYamlInfoSpecContainers[0].image).toBe(fakeImage);
     expect(metaYamlInfoSpecContainers[0].command).toStrictEqual(['/bin/sh']);
     expect(metaYamlInfoSpecContainers[0].args).toStrictEqual(['-c', './entrypoint.sh']);
   });
@@ -186,6 +196,9 @@ describe('Test CheTheiaPluginsAnalyzer', () => {
 
   test('nls property without nls field', async () => {
     const cheTheiaPluginMetaInfo = await generatePluginMetaInfo('my/first/plugin');
+    // remove preferences as well
+    delete cheTheiaPluginMetaInfo.preferences;
+
     delete Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageNlsJson;
     const packageJson = Array.from(cheTheiaPluginMetaInfo.vsixInfos.values())[0].packageJson;
     if (packageJson) {


### PR DESCRIPTION
### What does this PR do?
Allow to specify plugin preferences in che-theia-plugins.yaml file.
note: it will work only for plug-ins with sidecar for Devfile v1 (but anyway it was already the case as the only way was to patch entrypoint.sh)

#### dependency
- [x] Related to che-theia PR https://github.com/eclipse/che-theia/pull/1047

### how to define preferences:

preferences are at the same level than sidecar

```yaml
preferences:
  asciidoc.use_asciidoctorpdf: true
sidecar:
  ...
```

Here is how a generated meta.yaml looks like:
https://gist.github.com/benoitf/ba757696b6591f792487b7a006f21d15


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17975

### How to test this PR?
1. Look at unit tests
or
1. you can modify che-theia-plugins.yaml and see generated meta.yaml output
2. it depends on https://github.com/eclipse/che-theia/pull/1047


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: Ic8986139b1a8cee89111a4b1bf29193cbca23d0c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

