### PR TITLE
feat(preferences): Store preferences in che-theia-plugins.yaml file

### DIFF
--- a/che-theia-plugins.yaml
+++ b/che-theia-plugins.yaml
@@ -17,6 +17,8 @@ plugins:
   - repository:
       url: 'https://github.com/Microsoft/vscode-node-debug2'
       revision: v1.42.5
+    preferences:
+      debug.node.useV3: false
     sidecar:
       directory: node
       name: vscode-node-debug
@@ -140,6 +142,8 @@ plugins:
     extensions:
       - >-
         https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/v2249123/asciidoctor-vscode-v2.8.7.vsix
+    preferences:
+      asciidoc.use_asciidoctorpdf: true
     sidecar:
       directory: asciidoc
       name: asciidoctor-vscode
@@ -211,6 +215,8 @@ plugins:
     repository:
       url: 'https://github.com/redhat-developer/vscode-quarkus'
       revision: v1.7.0
+    preferences:
+      java.server.launchMode: Standard
     sidecar:
       directory: java
       name: vscode-quarkus
@@ -235,6 +241,8 @@ plugins:
     repository:
       url: 'https://github.com/redhat-developer/vscode-quarkus'
       revision: v1.5.0
+    preferences:
+      java.server.launchMode: Standard
     sidecar:
       directory: java8
       memoryLimit: 1500Mi
@@ -343,6 +351,8 @@ plugins:
     featured: true
     aliases:
       - redhat/java
+    preferences:
+      java.server.launchMode: Standard
     sidecar:
       directory: java
       name: vscode-java
@@ -363,6 +373,8 @@ plugins:
     repository:
       url: 'https://github.com/redhat-developer/vscode-java'
       revision: v0.63.0
+    preferences:
+      java.server.launchMode: Standard
     sidecar:
       directory: java8
       name: vscode-java
@@ -619,6 +631,8 @@ plugins:
   - repository:
       url: 'https://github.com/timonwong/vscode-shellcheck'
       revision: v0.13.2
+    preferences:
+      shellcheck.executablePath: /bin/shellcheck
     sidecar:
       directory: shellcheck
       name: shellcheck
@@ -702,6 +716,9 @@ plugins:
   - repository:
       url: https://github.com/castwide/vscode-solargraph
       revision: 212e76d
+    preferences:
+      solargraph.bundlerPath: /usr/local/bin/bundle
+      solargraph.commandPath: /usr/local/bundle/bin/solargraph
     sidecar:
       directory: ruby
       name: vscode-ruby

--- a/sidecars/asciidoc/etc/entrypoint.sh
+++ b/sidecars/asciidoc/etc/entrypoint.sh
@@ -27,10 +27,4 @@ if [ "${USER_ID}" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /
     sudo chown "${USER_ID}:${GROUP_ID}" /projects
 fi
 
-
-echo 'Setting "asciidoc.use_asciidoctorpdf" to true'
-mkdir -p "${CHE_PROJECTS_ROOT}"/.theia ;
-[ ! -f "${CHE_PROJECTS_ROOT}/.theia/settings.json" ] && echo "{}" > "${CHE_PROJECTS_ROOT}/.theia/settings.json"
-jq '. += {"asciidoc.use_asciidoctorpdf":true}' "${CHE_PROJECTS_ROOT}/.theia/settings.json" > /tmp/temp.json && mv /tmp/temp.json "${CHE_PROJECTS_ROOT}/.theia/settings.json"
-
 exec "$@"

--- a/sidecars/ruby/etc/entrypoint.sh
+++ b/sidecars/ruby/etc/entrypoint.sh
@@ -28,10 +28,4 @@ if [ "${USER_ID}" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /
     sudo chown "${USER_ID}:${GROUP_ID}" /projects
 fi
 
-echo 'Setting "solargraph.bundlerPath" to "/usr/local/bin/bundle" and  "solargraph.commandPath" to "/usr/local/bundle/bin/solargraph"'
-mkdir -p "${CHE_PROJECTS_ROOT}"/.theia ;
-[ ! -f "${CHE_PROJECTS_ROOT}/.theia/settings.json" ] && echo "{}" > "${CHE_PROJECTS_ROOT}/.theia/settings.json"
-jq '. += {"solargraph.bundlerPath":"/usr/local/bin/bundle"}' "${CHE_PROJECTS_ROOT}/.theia/settings.json" > /tmp/temp.json && mv /tmp/temp.json "${CHE_PROJECTS_ROOT}/.theia/settings.json"
-jq '. += {"solargraph.commandPath":"/usr/local/bundle/bin/solargraph"}' "${CHE_PROJECTS_ROOT}/.theia/settings.json" > /tmp/temp.json && mv /tmp/temp.json "${CHE_PROJECTS_ROOT}/.theia/settings.json"
-
 exec "$@"


### PR DESCRIPTION
### What does this PR do?
Once https://github.com/eclipse/che-plugin-registry/pull/904 is merged, we can define preferences in che-theia-plugins.yaml file

This PR remove sidecar entrypoint.sh patches that will not work with multi-root workspaces being enabled


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17975
and https://github.com/eclipse/che-plugin-registry/pull/904

### How to test this PR?
Check preferences are added as expected even if devfile use is not specifying these preferences

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I8784568c91f4744d7413a719492df86d53a2a873
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
